### PR TITLE
Allow reseting drives by implementing DRV_ALLRESET

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -121,6 +121,10 @@ func New(filename string, logger *slog.Logger) *CPM {
 		Desc:    "C_READSTRING",
 		Handler: SysCallReadString,
 	}
+	sys[13] = CPMHandler{
+		Desc:    "DRV_ALLRESET",
+		Handler: SysCallDriveAllReset,
+	}
 	sys[14] = CPMHandler{
 		Desc:    "DRV_SET",
 		Handler: SysCallDriveSet,

--- a/cpm/cpm_syscalls.go
+++ b/cpm/cpm_syscalls.go
@@ -114,6 +114,20 @@ func SysCallReadString(cpm *CPM) error {
 	return nil
 }
 
+// SysCallDriveAllReset resets the drives
+func SysCallDriveAllReset(cpm *CPM) error {
+	if cpm.fileIsOpen {
+		cpm.fileIsOpen = false
+		cpm.file.Close()
+	}
+
+	cpm.currentDrive = 1
+	cpm.userNumber = 0
+
+	cpm.CPU.States.AF.Hi = 0x00
+	return nil
+}
+
 // SysCallDriveSet updates the current drive number
 func SysCallDriveSet(cpm *CPM) error {
 	// The drive number passed to this routine is 0 for A:, 1 for B: up to 15 for P:.


### PR DESCRIPTION
This pull-request closes #19, by implementing syscall 13, DRV_ALLRESET.  This function is designed to reset the current disk and is called by ZORK1 just before a file save operation.