### PR TITLE
Implement sequential file read

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -149,6 +149,10 @@ func New(filename string, logger *slog.Logger) *CPM {
 		Desc:    "F_DELETE",
 		Handler: SysCallDeleteFile,
 	}
+	sys[20] = CPMHandler{
+		Desc:    "F_READ",
+		Handler: SysCallRead,
+	}
 	sys[21] = CPMHandler{
 		Desc:    "F_WRITE",
 		Handler: SysCallWrite,


### PR DESCRIPTION
This pull-request implements the sequential block-read operation, and closes #22.

With this I can restore thes aved-state I created in #23:

```
>restore
Load SAVE disk then enter file name.
(default file name is ZORK1.SAV).
Type <ENTER> to continue  > FOO

Load Game Disk if it was removed.
Type <ENTER> to continue >

Ok.

>inventory
You are carrying:
  A glass bottle
  The glass bottle contains:
    A quantity of water
  A leaflet

>look
Kitchen
You are in the kitchen of the white house. A table seems to
have been used recently for the preparation of food. A passage
leads to the west and a dark staircase can be seen leading
upward. A dark chimney leads down and to the east is a small
window which is open.
On the table is an elongated brown sack, smelling of hot
peppers.

>quit
Your score is 10 (total of 350 points), in 20 moves.
This gives you the rank of Beginner.
Do you wish to leave the game? (Y is affirmative): >y
```