### PR TITLE
Allow multiple open files

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -68,12 +68,6 @@ type CPM struct {
 	// Valid values are 00-15
 	userNumber uint8
 
-	// fileIsOpen records whether we have an open file.
-	fileIsOpen bool
-
-	// file has the handle to the open file, if fileIsOpen is true.
-	file *os.File
-
 	// findFirstResults is a sneaky cache of files that match a glob.
 	//
 	// For finding files CP/M uses "find first" to find the first result


### PR DESCRIPTION
This pull-request closes #27, by updating our file-handling to allow multiple open files at once.  Instead of storing a single file-handle when a file was created/opened, we installed stash the filehandle of the open-files we've created in the FCB.

We (ab)use the Al[0] field to store our file number and retrieve it later.

Testing:

* Loading zork works
  * Which uses random-reads to load zork.dat
* Loading/Saving games in zork works.

More than that?  Who knows.