### PR TITLE
Starting to get MBASIC.com to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This repository contains a CP/M emulator, with integrated CCP, which is primaril
 * Over time it has become more functional:
   * It can now run ZORK 1, 2, & 3, as well as The Hitchhiker's guide to the galaxy and other similar games.
 
-I've implemented enough of the BIOS functions to run simple well-behaved utilities, but I've not implemented any notion of disk access - only file-based I/O.
+I've implemented enough of the BIOS functions to run simple binaries, including Microsoft BASIC, but I've not implemented any notion of disk-based access.  (i.e. Opening, Reading/Writing, Closing files is absolutely fine, but any API call that refers to tracks, sectors, or disks will fail.)
 
-A companion repository contains a collection of vintage CP/M software you can use with this emulator:
+A companion repository contains a collection of vintage CP/M software you can use with this, or any other, emulator:
 
 * [https://github.com/skx/cpm-dist](https://github.com/skx/cpm-dist)
 
@@ -37,9 +37,10 @@ If neither of these options sufficed you may download the latest binary from [ou
 
 # Usage
 
-If you launch `cpmulator` with no arguments then the integrated CCP ("console command processor") will be launched, dropping you into a familiar shell - note here the filenames are presented in the old-school way, as per the later note on filesystems and filenames:
+If you launch `cpmulator` with no arguments then the integrated CCP ("console command processor") will be launched, dropping you into a familiar shell:
 
 ```sh
+$ cpmulator
 A>dir
 
 A: LICENSE .    | README  .MD  | CPMULATO.    | GO      .MOD
@@ -59,8 +60,8 @@ You can terminate the CCP by pressing Ctrl-C, or typing `EXIT`.  The following b
 * `CLS`
   * Clear the screen.
 * `DIR`
-  * List files, by default this uses "`*.*`", so files without suffixes will be hidden.
-    * Prefer "`DIR *`" if you want to see _everything_.
+  * List files, by default this uses "`*.*`".
+    * Try "`DIR *.COM`" if you want to see something more specific, for example.
 * `EXIT` / `HALT` / `QUIT`
   * Terminate the CCP.
 * `ERA`
@@ -97,6 +98,7 @@ There is a small mailbox here.
 
 >
 ```
+
 A companion repository contains a larger collection of vintage CP/M software you can use with this emulator:
 
 * [https://github.com/skx/cpm-dist](https://github.com/skx/cpm-dist)
@@ -105,12 +107,12 @@ A companion repository contains a larger collection of vintage CP/M software you
 
 ## Drives vs. Directories
 
-By default when you launch `cpmulator` with no arguments you'll be presented with the CCP interface, with A: as the current drive and A:, B:, C:, and all other drives, will refer to the current-working directory where you launched the emulator from.  This is perhaps the most practical way to get started, but it means that files are unique across drives:
+By default when you launch `cpmulator` with no arguments you'll be presented with the CCP interface, with A: as the current drive.   In this mode A:, B:, C:, and all other drives, will refer to the current-working directory where you launched the emulator from (i.e. they have the same view of files).  This is perhaps the most practical way to get started, but it means that files are unique across drives:
 
-* i.e. "`A:FOO`" is the same as "`B:FOO`"
+* i.e. "`A:FOO`" is the same as "`B:FOO`", and if you delete "`C:FOO`" you'll find it has vanished from all drives.
   * In short "`FOO`" will exist on drives `A:` all the way through to `P:`.
 
-If you prefer you can configure drives to have their contents from sub-directories upon the host system (i.e. the machine you're running on).  This means you need to create subdirectories, and the contents of those directories will only be visible on the appropriate drives:
+If you prefer you may configure drives to be distinct, each drive referring to a distinct sub-directory upon the host system (i.e. the machine you're running on):
 
 ```sh
 $ mkdir A/  ; touch A/LS.COM ; touch A/FOO.COM
@@ -140,7 +142,21 @@ A companion repository contains a larger collection of vintage CP/M software you
 
 * [https://github.com/skx/cpm-dist](https://github.com/skx/cpm-dist)
 
-This is arranged into subdirectories, on the assumption you'll run with the `-directories` flag, and the drives are thus used as a means of organization.
+This is arranged into subdirectories, on the assumption you'll run with the `-directories` flag, and the drives are thus used as a means of organization.  For example you might want to look at games, on the `G:` drive, or the BASIC interpreters on the `B:` drive:
+
+```
+frodo ~/Repos/github.com/skx/cpm-dist $ cpmulator  -directories
+A>dir
+No file
+
+A>g:
+G>dir *.com
+G: HITCH   .COM | LEATHER .COM | LIHOUSE .COM | PLANET  .COM
+G: ZORK1   .COM | ZORK2   .COM | ZORK3   .COM
+
+G>dir b:*.com
+B: MBASIC  .COM | TBASIC  .COM
+```
 
 Note that it isn't currently possibly to point different drives to arbitrary paths on your computer, but that might be considered if you have a use-case for it.
 
@@ -186,6 +202,15 @@ In case you don't I've added ensured I also commit the generated binaries to the
 * Much of the functionality of this repository comes from the [excellent Z80 emulator library](https://github.com/koron-go/z80) it is using, written by @koron-go.
 * The CCP comes from [my fork](https://github.com/skx/z80-playground-cpm-fat/) of the original [cpm-fat](https://github.com/z80playground/cpm-fat/)
   * However this is largely unchanged from the [original CCP](http://www.cpm.z80.de/source.html) from Digital Research, although I did add the `CLS`, `EXIT`, `HALT` & `QUIT` commands.
+
+When I was uncertain of how to implement a specific system call the following two emulators were also useful:
+
+* [https://github.com/ivanizag/iz-cpm](https://github.com/ivanizag/iz-cpm)
+  * Portable CP/M emulation to run CP/M 2.2 binaries for Z80.
+  * Written in Rust.
+* [https://github.com/jhallen/cpm](https://github.com/jhallen/cpm)
+  * Run CP/M commands in Linux/Cygwin with this Z80 / BDOS / ADM-3A emulator.
+  * Written in C.
 
 
 

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -177,6 +177,14 @@ func New(logger *slog.Logger) *CPM {
 		Desc:    "C_RAWIO",
 		Handler: SysCallRawIO,
 	}
+	sys[7] = CPMHandler{
+		Desc:    "GET_IOBYTE",
+		Handler: SysCallGetIOByte,
+	}
+	sys[8] = CPMHandler{
+		Desc:    "SET_IOBYTE",
+		Handler: SysCallSetIOByte,
+	}
 	sys[9] = CPMHandler{
 		Desc:    "C_WRITESTRING",
 		Handler: SysCallWriteString,

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -91,6 +91,11 @@ type CPM struct {
 	// to basically keep track of multibyte output
 	auxStatus int
 
+	// auxIO is used to disable character output if aux I/O has been seen.
+	// This is a bit hacky, but will resolve the issue of mixed outputs in
+	// Microsoft BASIC
+	auxIO bool
+
 	// x holds the character X position, when using AUX I/O.
 	// It is set/used by escape sequences.
 	x uint8

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -91,10 +91,6 @@ type CPM struct {
 	// to basically keep track of multibyte output
 	auxStatus int
 
-	// pending contains any pending character "accidentally" read via the
-	// SysCallConsoleStatus function
-	pending uint8
-
 	// x holds the character X position, when using AUX I/O.
 	// It is set/used by escape sequences.
 	x uint8

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -91,6 +91,10 @@ type CPM struct {
 	// to basically keep track of multibyte output
 	auxStatus int
 
+	// pending contains any pending character "accidentally" read via the
+	// SysCallConsoleStatus function
+	pending uint8
+
 	// x holds the character X position, when using AUX I/O.
 	// It is set/used by escape sequences.
 	x uint8

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -90,8 +90,14 @@ type CPM struct {
 	// device.  This is used by MBASIC amongst other things, and we use it
 	// to basically keep track of multibyte output
 	auxStatus int
-	x         uint8
-	y         uint8
+
+	// x holds the character X position, when using AUX I/O.
+	// It is set/used by escape sequences.
+	x uint8
+
+	// y holds the character Y position, when using AUX I/O.
+	// It is set/used by escape sequences.
+	y uint8
 
 	// Syscalls contains the syscalls we know how to emulate, indexed
 	// by their ID.
@@ -327,8 +333,7 @@ func (cpm *CPM) LoadBinary(filename string) error {
 // we don't overlap with our CCP, or "large programs" loaded at 0x0100
 func (cpm *CPM) fixupRAM() {
 	i := 0
-	var CBIOS int
-	CBIOS = 0xFE00
+	CBIOS := 0xFE00
 	NENTRY := 30
 
 	SETMEM := func(a int, v int) {

--- a/cpm/cpm_syscalls.go
+++ b/cpm/cpm_syscalls.go
@@ -264,6 +264,33 @@ func SysCallRawIO(cpm *CPM) error {
 	return nil
 }
 
+// SysCallGetIOByte gets the IOByte, which is used to describe which devices
+// are used for I/O.  No CP/M utilities use it, except for STAT and PIP.
+//
+// The IOByte lives at 0x0003 in RAM, so it is often accessed directly when it is used.
+func SysCallGetIOByte(cpm *CPM) error {
+
+	// Get the value
+	c := cpm.Memory.Get(0x003)
+
+	// return it
+	cpm.CPU.States.AF.Hi = c
+
+	return nil
+}
+
+// SysCallSetIOByte sets the IOByte, which is used to describe which devices
+// are used for I/O.  No CP/M utilities use it, except for STAT and PIP.
+//
+// The IOByte lives at 0x0003 in RAM, so it is often accessed directly when it is used.
+func SysCallSetIOByte(cpm *CPM) error {
+
+	// Set the value
+	cpm.Memory.Set(0x003, cpm.CPU.States.DE.Lo)
+
+	return nil
+}
+
 // SysCallWriteString writes the $-terminated string pointed to by DE to STDOUT
 func SysCallWriteString(cpm *CPM) error {
 	addr := cpm.CPU.States.DE.U16()

--- a/cpm/cpm_syscalls.go
+++ b/cpm/cpm_syscalls.go
@@ -104,36 +104,26 @@ func SysCallAuxWrite(cpm *CPM) error {
 		switch c {
 		case 0x07: /* BEL: flash screen */
 			fmt.Printf("\033[?5h\033[?5l")
-			break
 		case 0x7f: /* DEL: echo BS, space, BS */
 			fmt.Printf("\b \b")
-			break
 		case 0x1a: /* adm3a clear screen */
 			fmt.Printf("\033[H\033[2J")
-			break
 		case 0x0c: /* vt52 clear screen */
 			fmt.Printf("\033[H\033[2J")
-			break
 		case 0x1e: /* adm3a cursor home */
 			fmt.Printf("\033[H")
-			break
 		case 0x1b:
 			cpm.auxStatus = 1 /* esc-prefix */
-			break
 		case 1:
 			cpm.auxStatus = 2 /* cursor motion prefix */
-			break
 		case 2: /* insert line */
 			fmt.Printf("\033[L")
-			break
 		case 3: /* delete line */
 			fmt.Printf("\033[M")
-			break
 		case 0x18, 5: /* clear to eol */
 			fmt.Printf("\033[K")
-			break
 		case 0x12, 0x13:
-			break
+			// nop
 		default:
 			fmt.Printf("%c", c)
 		}
@@ -141,113 +131,84 @@ func SysCallAuxWrite(cpm *CPM) error {
 		switch c {
 		case 0x1b:
 			fmt.Printf("%c", c)
-			break
 		case '=', 'Y':
 			cpm.auxStatus = 2
-			break
 		case 'E': /* insert line */
 			fmt.Printf("\033[L")
-			break
 		case 'R': /* delete line */
 			fmt.Printf("\033[M")
-			break
 		case 'B': /* enable attribute */
 			cpm.auxStatus = 4
-			break
 		case 'C': /* disable attribute */
 			cpm.auxStatus = 5
-			break
 		case 'L', 'D': /* set line */ /* delete line */
 			cpm.auxStatus = 6
-			break
 		case '*', ' ': /* set pixel */ /* clear pixel */
 			cpm.auxStatus = 8
-			break
 		default: /* some true ANSI sequence? */
 			cpm.auxStatus = 0
 			fmt.Printf("%c%c", 0x1b, c)
-			break
 		}
 	case 2:
 		cpm.y = c - ' ' + 1
 		cpm.auxStatus = 3
-		break
 	case 3:
 		cpm.x = c - ' ' + 1
 		cpm.auxStatus = 0
 		fmt.Printf("\033[%d;%dH", cpm.y, cpm.x)
-		break
 	case 4: /* <ESC>+B prefix */
 		cpm.auxStatus = 0
 		switch c {
 		case '0': /* start reverse video */
 			fmt.Printf("\033[7m")
-			break
 		case '1': /* start half intensity */
 			fmt.Printf("\033[1m")
-			break
 		case '2': /* start blinking */
 			fmt.Printf("\033[5m")
-			break
 		case '3': /* start underlining */
 			fmt.Printf("\033[4m")
-			break
 		case '4': /* cursor on */
 			fmt.Printf("\033[?25h")
-			break
 		case '5': /* video mode on */
-			break
+			// nop
 		case '6': /* remember cursor position */
 			fmt.Printf("\033[s")
-			break
 		case '7': /* preserve status line */
-			break
+			// nop
 		default:
 			fmt.Printf("%cB%c", 0x1b, c)
 		}
-		break
 	case 5: /* <ESC>+C prefix */
 		cpm.auxStatus = 0
 		switch c {
 		case '0': /* stop reverse video */
 			fmt.Printf("\033[27m")
-			break
 		case '1': /* stop half intensity */
 			fmt.Printf("\033[m")
-			break
 		case '2': /* stop blinking */
 			fmt.Printf("\033[25m")
-			break
 		case '3': /* stop underlining */
 			fmt.Printf("\033[24m")
-			break
 		case '4': /* cursor off */
 			fmt.Printf("\033[?25l")
-			break
 		case '6': /* restore cursor position */
 			fmt.Printf("\033[u")
-			break
 		case '5': /* video mode off */
-			break
+			// nop
 		case '7': /* don't preserve status line */
-			break
+			// nop
 		default:
 			fmt.Printf("%cC%c", 0x1b, c)
 		}
-		break
 		/* set/clear line/point */
 	case 6:
 		cpm.auxStatus++
-		break
 	case 7:
 		cpm.auxStatus++
-		break
 	case 8:
 		cpm.auxStatus++
-		break
 	case 9:
 		cpm.auxStatus = 0
-		break
 	}
 
 	return nil

--- a/io/io.go
+++ b/io/io.go
@@ -1,0 +1,116 @@
+// Package io is designed to collect the code that reads from STDIN.
+//
+// There are, broadly speaking, two things we need to do here:
+//
+// * See if there is any available (single-character) input.
+//
+// * Read a single byte of input.
+//
+// This package is explicitly not used for _line_ based IO (yet).
+package io
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+
+	"golang.org/x/term"
+)
+
+// IO is used to hold our package state
+type IO struct {
+	// pending holds any pending byte
+	pending byte
+}
+
+// New is our package constructor.
+func New() *IO {
+	return &IO{}
+}
+
+// GetAvailableChar returns the character that we detected in IsPending.
+func (io *IO) GetAvailableChar() byte {
+	c := io.pending
+	io.pending = 0x00
+	return c
+}
+
+// BlockForCharacter returns the next character from the console, blocking until
+// one is available.
+func (io *IO) BlockForCharacter() (byte, error) {
+
+	// switch stdin into 'raw' mode
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		return 0x00, fmt.Errorf("error making raw terminal %s", err)
+	}
+
+	// read only a single byte
+	b := make([]byte, 1)
+	_, err = os.Stdin.Read(b)
+	if err != nil {
+		return 0x00, fmt.Errorf("error reading a byte from stdin %s", err)
+	}
+
+	// restore the state of the terminal to avoid mixing RAW/Cooked
+	err = term.Restore(int(os.Stdin.Fd()), oldState)
+	if err != nil {
+		return 0x00, fmt.Errorf("error restoring terminal state %s", err)
+	}
+
+	// Return the character we read
+	return b[0], nil
+}
+
+// IsPending returns true if there is pending input
+func (io *IO) IsPending() (bool, error) {
+
+	// Set STDIN to be non-blocking.
+	if err1 := syscall.SetNonblock(0, true); err1 != nil {
+		return false, fmt.Errorf("failed to set non-blocking stdin %s", err1)
+	}
+
+	// Switch STDIN into 'raw' mode.
+	oldState, err2 := term.MakeRaw(int(os.Stdin.Fd()))
+	if err2 != nil {
+		return false, fmt.Errorf("error making raw terminal %s", err2)
+	}
+
+	// We'll read only a single byte of input, into this buffer
+	b := make([]byte, 1)
+
+	// NOTE: This doesn't work without the non-blocking mode having been
+	// set previously.
+	os.Stdin.SetDeadline(time.Now().Add(time.Millisecond * 1))
+
+	// Try the read
+	n, err := os.Stdin.Read(b)
+
+	// restore the state of the terminal to avoid mixing RAW/Cooked
+	err3 := term.Restore(int(os.Stdin.Fd()), oldState)
+	if err3 != nil {
+		return false, fmt.Errorf("error restoring terminal state %s", err3)
+	}
+
+	// restore the non-blocking state
+	if err4 := syscall.SetNonblock(0, false); err4 != nil {
+		return false, fmt.Errorf("failed to restore non-blocking %s", err4)
+	}
+
+	// If we got a timeout, or some other error, then we assume
+	// there is no character pending
+	if err != nil {
+		return false, nil
+	}
+
+	// If we read one byte, as we hoped to do then we can record
+	// that byte, and return it
+	if n == 1 {
+		io.pending = b[0]
+		return true, nil
+	}
+
+	// Can't happen?
+	return false, nil
+}

--- a/io/io.go
+++ b/io/io.go
@@ -82,7 +82,7 @@ func (io *IO) IsPending() (bool, error) {
 
 	// NOTE: This doesn't work without the non-blocking mode having been
 	// set previously.
-	os.Stdin.SetDeadline(time.Now().Add(time.Millisecond * 1))
+	_ = os.Stdin.SetDeadline(time.Now().Add(time.Millisecond * 1))
 
 	// Try the read
 	n, err := os.Stdin.Read(b)

--- a/io/io.go
+++ b/io/io.go
@@ -20,7 +20,7 @@ import (
 
 // IO is used to hold our package state
 type IO struct {
-	// pending holds any pending byte
+	// pending holds any pending byte.
 	pending byte
 }
 
@@ -63,7 +63,7 @@ func (io *IO) BlockForCharacter() (byte, error) {
 	return b[0], nil
 }
 
-// IsPending returns true if there is pending input
+// IsPending returns true if there is pending input.
 func (io *IO) IsPending() (bool, error) {
 
 	// Set STDIN to be non-blocking.
@@ -82,7 +82,7 @@ func (io *IO) IsPending() (bool, error) {
 
 	// NOTE: This doesn't work without the non-blocking mode having been
 	// set previously.
-	_ = os.Stdin.SetDeadline(time.Now().Add(time.Millisecond * 1))
+	_ = os.Stdin.SetDeadline(time.Now().Add(time.Millisecond * 10))
 
 	// Try the read
 	n, err := os.Stdin.Read(b)


### PR DESCRIPTION
This pull-request allows MBASIC.COM to launch and run :)

Once complete it will close #49, and as part of the implementation changes introduced in this pull-request #50 will also be closed.

There are two main changes to get MBASIC running, and that is largely because it is not a "well-behaved" application:

* We setup fake entrypoints in the zero-page.
  * This ensures that the various RST XXX instructions will ultimately jump to our handlers.
  * This is necessary because `mbasic` is not well-behaved, and doesn't invoke CP/M functions via `call 0x0005`.
* We implemented the aux I/O routines.
  * The output routine attempts to convert vt52/adm3a to ANSI

This pull-request, as-is, works well enough to launch and operate `mbasic` however there are some spurious output characters that need to be eliminated..