### PR TITLE
55 drives

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,6 @@ Let me know by filing an issue.  If your program is "real" then it is highly lik
 
 Outstanding issues I'm aware of:
 
-* Inconsistent handling of Drives in FCB entries.
-  * There seems to be no suffering here, but ..
 * I don't implement some of the basic BIOS calls that might be useful
   * Get free RAM, etc, etc.
   * These will be added over time as their absence causes program-failures.


### PR DESCRIPTION
Use drive-names when FCB tells us to.
    
This pull-request closes #55 by updating file-handling to account for the drive specified in the FCB for the obvious cases:
    
* FileOpen
* MakeFile
* FileDelete
