### PR TITLE
Added command-line arguments for printer/logfile-paths.

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -6,10 +6,10 @@
 
 The emulator can be configured to log all the syscalls, or bios requests, that it was asked to carry out.
 
-To enable logging set the environmental variable `DEBUG` to any non-empty value, and redirect STDERR to capture these logs into a file:
+To enable logging specify the path to a file, with the `-log-path` command-line argument:
 
 ```sh
-DEBUG=1 cpmulator [args] 2>logs.out
+cpmulator -log-path debug.log [args] 2>logs.out
 ```
 
 The logging is produced via the golang `slog` package, and will be written in JSON format for ease of processing.  However note that each line is a distinct record and we don't have an array of logs.
@@ -17,13 +17,13 @@ The logging is produced via the golang `slog` package, and will be written in JS
 You can convert the flat file to a JSON array object using `jq` like so:
 
 ```sh
-jq --slurp '.' logs.out > logs.json
+jq --slurp '.' debug.log > debug.json
 ```
 
 Once you have the logs as a JSON array you can use the `jq` tool to count unique syscalls, or perform further processing like so:
 
 ```sh
-cat logs.json | jq '.[].name' | sort | grep -v null | uniq --count  | sort --numeric-sort
+cat debug.json | jq '.[].name' | sort | grep -v null | uniq --count  | sort --numeric-sort
 ```
 This will give output like this:
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,21 @@ You can also launch a binary directly by specifying it's path upon the command-l
 $ cpmulator /path/to/binary [optional-args]
 ```
 
+Other options are shown in the output of `cpmulator -help`, but in brief:
+
+* `-cd /path/to/directory`
+  * Change to the given directory before running.
+* `-directories`
+  * Use directories on the host for drive-contents, discussed later in this document.
+* `-log-path /path/to/file`
+  * Output debug-logs to the given file, creating it if necessary.
+* `-prn-path /path/to/file`
+  * All output which CP/M sends to the "printer" will be written to the given file.
 
 
-## Sample Binaries
+
+
+# Sample Binaries
 
 I've placed some games within the `dist/` directory, to make it easier for you to get started:
 
@@ -127,7 +139,8 @@ A companion repository contains a larger collection of vintage CP/M software you
 
 
 
-## Drives vs. Directories
+
+# Drives vs. Directories
 
 By default when you launch `cpmulator` with no arguments you'll be presented with the CCP interface, with A: as the current drive.   In this mode A:, B:, C:, and all other drives, will refer to the current-working directory where you launched the emulator from (i.e. they have the same view of files).  This is perhaps the most practical way to get started, but it means that files are repeated across drives:
 
@@ -181,7 +194,8 @@ Note that it isn't currently possibly to point different drives to arbitrary pat
 
 
 
-## Implemented Syscalls
+
+# Implemented Syscalls
 
 
 You can see the list of implemented syscalls, along with a mention of how complete their implementation is, by running:
@@ -208,11 +222,12 @@ $ cpmulator -syscalls
 34 F_WRITERAND
 ```
 
-Items marked "FAKE" return "appropriate" values, rather than real values.  Or are otherwise incomplete.  The only function with significantly different behaviour is `L_WRITE` which is designed to send a single character to a connected printer - that function appends the character to the file `print.log` in the current-directory, creating it if necessary.
+Items marked "FAKE" return "appropriate" values, rather than real values.  Or are otherwise incomplete.  The only function with significantly different behaviour is `L_WRITE` which is designed to send a single character to a connected printer - that function appends the character to the file `print.log` in the current-directory, creating it if necessary.  (The path may be altered via the `-prn-path` command-line argument.)
 
 
 
-## Debugging Failures & Tweaking Behaviour
+
+# Debugging Failures & Tweaking Behaviour
 
 When an unimplemented BIOS call is attempted the program it will abort with a fatal error, for example:
 
@@ -230,16 +245,16 @@ If things are _mostly_ working, but something is not quite producing the correct
 
 * [DEBUGGING.md](DEBUGGING.md)
 
-Here is the complete list of environmental variables which influence behaviour:
+The following environmental variables influence runtime behaviour:
 
 | Variable    | Purpose                                                       |
 |-------------|---------------------------------------------------------------|
-| DEBUG       | Send a log of CP/M syscalls to STDERR                         |
 | SIMPLE_CHAR | Avoid the attempted VT52 output conversion.                   |
 
 
 
-## Sample Programs
+
+# Sample Programs
 
 You'll see some Z80 assembly programs beneath [samples](samples/) which are used to check my understanding.  If you have the `pasmo` compiler enabled you can build them all by running "make", in case you don't I've also committed the generated binaries.
 
@@ -264,7 +279,8 @@ When I was uncertain of how to implement a specific system call the following tw
 
 
 
-## References
+
+# References
 
 * [Digital Research - CP/M Operating System Manual](http://www.gaby.de/cpm/manuals/archive/cpm22htm/)
   * Particularly the syscall reference in [Section 5: CP/M 2 System Interface](http://www.gaby.de/cpm/manuals/archive/cpm22htm/ch5.htm).

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -90,6 +90,10 @@ type CPM struct {
 	// for block I/O.
 	dma uint16
 
+	// prnPath contains the name of a file to write all printer-output
+	// to.
+	prnPath string
+
 	// start contains the location to which we load our binaries,
 	// and execute them from.  This is specifically a variable because
 	// while all CP/M binaries are loaded at 0x0100 the CCP we can
@@ -158,7 +162,7 @@ type CPM struct {
 }
 
 // New returns a new emulation object
-func New(logger *slog.Logger) *CPM {
+func New(logger *slog.Logger, prn string) *CPM {
 
 	//
 	// Create and populate our syscall table
@@ -319,6 +323,7 @@ func New(logger *slog.Logger) *CPM {
 		dma:      0x0080,
 		start:    0x0100,
 		files:    make(map[uint16]FileCache),
+		prnPath:  prn,
 	}
 	return tmp
 }

--- a/cpm/cpm_syscalls.go
+++ b/cpm/cpm_syscalls.go
@@ -90,10 +90,11 @@ func SysCallAuxRead(cpm *CPM) error {
 }
 
 // SysCallPrinterWrite should send a single character to the printer,
-// we fake that by writing to the file "print.log" in the current directory.
+// we fake that by writing to a file instead.
 func SysCallPrinterWrite(cpm *CPM) error {
-	// If the file doesn't exist, create it, or append to the file
-	f, err := os.OpenFile("print.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+
+	// If the file doesn't exist, create it.
+	f, err := os.OpenFile(cpm.prnPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("SysCallPrinterWrite: Failed to open file 'print.log' %s", err)
 	}


### PR DESCRIPTION
This closes #64 by adding command-line flags to specify the path to a logfile, in preference to the previous use of the $DEBUG environmental variable.

We've also allowed the user to specify the path for printer-output, although the previous default remains in place.