### PR TITLE
Resolved confusion about BDOS vs BIOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ Over time this project has become more complete, and more complex.  I've impleme
   * You can edit and compile C code within the emulator, then run it!
 * Borland's Turbo Pascal
   * You can edit and compile Pascal code within the emulator, then run it!
-* Microsoft BASIC
-* Various Infocom games
+* Many early Infocom games:
   * Zork 1, 2, & 3.
   * Planetfall.
   * etc.
+* Microsoft BASIC
+* Wordstar
 
 The biggest caveat of the emulator is that I've not implemented any notion of disk-based access.  This means that, for example opening, reading/writing, and closing files is absolutely fine, but any API call that refers to tracks, sectors, or disks will fail.
 

--- a/cpm/cpm_syscalls.go
+++ b/cpm/cpm_syscalls.go
@@ -53,13 +53,6 @@ func SysCallReadChar(cpm *CPM) error {
 // SysCallWriteChar writes the single character in the E register to STDOUT.
 func SysCallWriteChar(cpm *CPM) error {
 
-	// auxIO is set when we see A_READ/A_WRITE
-	//
-	// Mixing I/O modes is not recommended.
-	if cpm.auxIO {
-		return nil
-	}
-
 	cpm.outC(cpm.CPU.States.DE.Lo)
 
 	return nil
@@ -117,9 +110,6 @@ func SysCallPrinterWrite(cpm *CPM) error {
 // SysCallAuxWrite writes the single character in the C register
 // auxillary / punch output.
 func SysCallAuxWrite(cpm *CPM) error {
-
-	// Now we're using aux I/O
-	cpm.auxIO = true
 
 	// The character we're going to write
 	c := cpm.CPU.States.BC.Lo

--- a/main.go
+++ b/main.go
@@ -51,14 +51,23 @@ func main() {
 			ids = append(ids, int(i))
 		}
 		sort.Ints(ids)
+
+		fmt.Printf("BDOS\n")
 		for id := range ids {
 			ent := c.Syscalls[uint8(id)]
 			fake := ""
 			if ent.Fake {
 				fake = "FAKE"
 			}
-			fmt.Printf("%02d %-20s %s\n", int(id), ent.Desc, fake)
+			fmt.Printf("\t%02d %-20s %s\n", int(id), ent.Desc, fake)
 		}
+		fmt.Printf("BIOS\n")
+		fmt.Printf("\t00  BOOT                FAKE\n")
+		fmt.Printf("\t01  WBOOT               FAKE\n")
+		fmt.Printf("\t02  CONST\n")
+		fmt.Printf("\t03  CONIN\n")
+		fmt.Printf("\t04  CONOUT\n")
+
 		return
 	}
 	// Default program to execute, and arguments to pass to program


### PR DESCRIPTION
This pull-request closes #68 by resolving the confusion about BIOS and BDOS - I understand now why I had issues with mixing RawIO and mixed IO it was because I was using the wrong handler for the same things!

This pull-request:

* Explicitly marks the majority of our syscalls as being BDOS functions.
* Implements the four necessary BIOS calls to make my programs work.

This completely resolves the issue I had with laggy LIST and PRINT in Microsoft BASIC, allows WORDSTAR.COM to launch, and fixes some other oddities.

I'm so happy!