### PR TITLE
Cap the drive at P, naturally.

### DIFF
--- a/cpm/cpm_syscalls.go
+++ b/cpm/cpm_syscalls.go
@@ -316,9 +316,20 @@ func SysCallDriveAllReset(cpm *CPM) error {
 
 // SysCallDriveSet updates the current drive number.
 func SysCallDriveSet(cpm *CPM) error {
-	// The drive number passed to this routine is 0 for A:, 1 for B: up to 15 for P:.
-	cpm.currentDrive = (cpm.CPU.States.AF.Hi & 0x0F)
 
+	// The drive number passed to this routine is 0 for A:, 1 for B:
+	// up to 15 for P:.
+	drv := cpm.CPU.States.AF.Hi
+
+	// P: is the maximum
+	if drv > 15 {
+		drv = 15
+	}
+
+	// set the drive
+	cpm.currentDrive = drv
+
+	// Update RAM
 	cpm.Memory.Set(0x0004, cpm.currentDrive)
 
 	// Return values:


### PR DESCRIPTION
This pull-request closes #67 by capping the valid drive at the expected number (15/P:).  Rather than AND we just use the last valid drive if it was too high.