### PR TITLE
Trap warm/cold-boots.

### DIFF
--- a/main.go
+++ b/main.go
@@ -179,6 +179,11 @@ func main() {
 				return
 			}
 
+			// Reboot attempt, also fine
+			if err == cpm.ErrBoot {
+				return
+			}
+
 			// Deliberate stop of execution.
 			if err == cpm.ErrExit {
 				return
@@ -208,6 +213,9 @@ func main() {
 		err := obj.Execute(args)
 		if err != nil {
 
+			if err == cpm.ErrBoot {
+				continue
+			}
 			// Deliberate stop of execution.
 			if err == cpm.ErrHalt {
 				return


### PR DESCRIPTION
In the case we're running CCP:

* Warm boot - restarts CCP
* Cold boot - restarts CCP

In the case we're running a binary:

* Warm boot - terminates cleanly.
* Cold boot - terminates cleanly.

This closes #72.