### PR TITLE
Added "LIST" to BIOS functions.

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -17,7 +17,6 @@ import (
 	"github.com/koron-go/z80"
 	"github.com/skx/cpmulator/ccp"
 	"github.com/skx/cpmulator/fcb"
-	cpmio "github.com/skx/cpmulator/io"
 	"github.com/skx/cpmulator/memory"
 )
 
@@ -718,55 +717,8 @@ func (cpm *CPM) Out(addr uint8, val uint8) {
 		return
 	}
 
-	switch val {
-	case 00:
-		cpm.Logger.Info("BIOS syscall 0x00 - can't happen",
-			slog.String("BIOS", "BOOT"))
-
-		// Set entry-point to 0x0000 which will result in
-		// a boot-trap
-		cpm.CPU.States.PC = 0x0000
-	case 01:
-		cpm.Logger.Info("BIOS syscall 0x01",
-			slog.String("BIOS", "WBOOT"))
-
-		// Set entry-point to 0x0000 which will result in
-		// a boot-trap
-		cpm.CPU.States.PC = 0x0000
-	case 02:
-		// Returns its status in A; 0 if no character is ready, 0FFh if one is.
-		cpm.Logger.Info("BIOS syscall 0x02",
-			slog.String("BIOS", "CONST"))
-
-		// Nothing pending - FAKE
-		cpm.CPU.States.AF.Hi = 0x00
-
-	case 03:
-		cpm.Logger.Info("BIOS syscall 0x03",
-			slog.String("BIOS", "CONIN"))
-		// Wait until the keyboard is ready to provide a character, and return it in A.
-		// Use our I/O package
-		obj := cpmio.New(cpm.Logger)
-
-		out, err := obj.BlockForCharacter()
-		if err != nil {
-			// record the error
-			cpm.ioErr = err
-			// halt processing.
-			cpm.CPU.HALT = true
-		}
-		cpm.CPU.States.AF.Hi = out
-
-	case 04:
-		cpm.Logger.Info("BIOS syscall 0x04",
-			slog.String("BIOS", "CONOUT"))
-
-		// Write the character in C to the screen.
-		c := cpm.CPU.States.BC.Lo
-		cpm.outC(c)
-	default:
-		cpm.Logger.Error("Unimplemented BIOS syscall",
-			slog.Int("syscall", int(val)),
-			slog.String("syscallHex", fmt.Sprintf("0x%02X", val)))
-	}
+	//
+	// Invoke the handler, in cpm_bios.go
+	//
+	cpm.BiosHandler(val)
 }

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -196,6 +196,7 @@ func New(logger *slog.Logger, prn string) *CPM {
 	sys[5] = CPMHandler{
 		Desc:    "L_WRITE",
 		Handler: SysCallPrinterWrite,
+		Fake:    true,
 	}
 	sys[6] = CPMHandler{
 		Desc:    "C_RAWIO",
@@ -358,9 +359,10 @@ func New(logger *slog.Logger, prn string) *CPM {
 	b[5] = CPMHandler{
 		Desc:    "LIST",
 		Handler: BiosSysCallPrintChar,
+		Fake:    true,
 	}
 
-	// Create the object
+	// Create the emulator object and return it
 	tmp := &CPM{
 		Logger:       logger,
 		BDOSSyscalls: sys,
@@ -581,6 +583,7 @@ func (cpm *CPM) Execute(args []string) error {
 	//
 	//  0x0000 - is the boot address of the Z80 processor.
 	//  0x0005 - The CPM BDOS entrypoint.
+	//
 	cpm.CPU.BreakPoints = map[uint16]struct{}{}
 	cpm.CPU.BreakPoints[0x0000] = struct{}{}
 	cpm.CPU.BreakPoints[0x0005] = struct{}{}

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -1,7 +1,8 @@
-// This file contains the implementations for the CP/M calls we emulate.
+// This file implements the BDOS function-calls.
 //
-// NOTE: They are added to the syscalls map in cpm.go.
+// These are documented online:
 //
+// * https://www.seasip.info/Cpm/bdos.html
 
 package cpm
 
@@ -111,11 +112,6 @@ func SysCallRawIO(cpm *CPM) error {
 	case 0xFF, 0xFD:
 
 		out, err := obj.BlockForCharacter()
-
-		// I think this is correct: but it breaks zork
-		// TODO: Reassess
-		// With this in-place zork runs, mbasic runs, and turbo.com runs
-		//		out, err := obj.GetCharOrNull()
 		if err != nil {
 			return err
 		}

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -86,25 +86,9 @@ func SysCallAuxRead(cpm *CPM) error {
 // we fake that by writing to a file instead.
 func SysCallPrinterWrite(cpm *CPM) error {
 
-	// If the file doesn't exist, create it.
-	f, err := os.OpenFile(cpm.prnPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("SysCallPrinterWrite: Failed to open file 'print.log' %s", err)
-	}
-
-	data := make([]byte, 1)
-	data[0] = cpm.CPU.States.BC.Lo
-	_, err = f.Write(data)
-	if err != nil {
-		return fmt.Errorf("SysCallPrinterWrite: Failed to write %s", err)
-	}
-
-	err = f.Close()
-	if err != nil {
-		return fmt.Errorf("SysCallPrinterWrite: Failed to close %s", err)
-	}
-
-	return nil
+	// write the character to our printer-file
+	err := cpm.prnC(cpm.CPU.States.BC.Lo)
+	return err
 }
 
 // SysCallAuxWrite writes the single character in the C register

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -1,3 +1,9 @@
+// This file implements the BIOS function-calls.
+//
+// These are documented online:
+//
+// * https://www.seasip.info/Cpm/bios.html
+
 package cpm
 
 import (
@@ -24,6 +30,8 @@ func BiosSysCallConsoleStatus(cpm *CPM) error {
 	return nil
 }
 
+// BiosSysCallConsoleInput should block for a single character of input,
+// and return the character pressed in the A-register.
 func BiosSysCallConsoleInput(cpm *CPM) error {
 
 	// Wait until the keyboard is ready to provide a character, and return it in A.
@@ -39,6 +47,8 @@ func BiosSysCallConsoleInput(cpm *CPM) error {
 	return nil
 }
 
+// BiosSysCallConsoleOutput should write a single character, in the C-register,
+// to the console.
 func BiosSysCallConsoleOutput(cpm *CPM) error {
 
 	// Write the character in C to the screen.
@@ -48,6 +58,8 @@ func BiosSysCallConsoleOutput(cpm *CPM) error {
 	return nil
 }
 
+// BiosSysCallPrintChar should print the specified character, in the C-register,
+// to the printer.  We fake that and write to a file instead.
 func BiosSysCallPrintChar(cpm *CPM) error {
 
 	// Write the character in C to the printer
@@ -59,10 +71,9 @@ func BiosSysCallPrintChar(cpm *CPM) error {
 }
 
 // BiosHandler is involved when a BIOS syscall needs to be executed,
-// which is handled via trapping RST instructions and using a short
-// trampoline.
+// which is handled via a small trampoline.
 //
-// The functions here are far fewer than those in the cpm_bdos.go files.
+// These are looked up in the BIOSSyscalls map.
 func (cpm *CPM) BiosHandler(val uint8) {
 
 	// Lookup the handler

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -1,0 +1,81 @@
+package cpm
+
+import (
+	"fmt"
+	"log/slog"
+
+	cpmio "github.com/skx/cpmulator/io"
+)
+
+// BiosHandler is involved when a BIOS syscall needs to be executed,
+// which is handled via trapping RST instructions and using a short
+// trampoline.
+//
+// The functions here are far fewer than those in the cpm_bdos.go files.
+func (cpm *CPM) BiosHandler(val uint8) {
+
+	switch val {
+	case 00:
+		cpm.Logger.Info("BIOS syscall 0x00",
+			slog.String("BIOS", "BOOT"))
+
+		// Set entry-point to 0x0000 which will result in
+		// a boot-trap.
+		cpm.CPU.States.PC = 0x0000
+	case 01:
+		cpm.Logger.Info("BIOS syscall 0x01",
+			slog.String("BIOS", "WBOOT"))
+
+		// Set entry-point to 0x0000 which will result in
+		// a boot-trap.
+		cpm.CPU.States.PC = 0x0000
+	case 02:
+		// Returns its status in A; 0 if no character is ready, 0FFh if one is.
+		cpm.Logger.Info("BIOS syscall 0x02",
+			slog.String("BIOS", "CONST"))
+
+		// Nothing pending - FAKE
+		cpm.CPU.States.AF.Hi = 0x00
+
+	case 03:
+		cpm.Logger.Info("BIOS syscall 0x03",
+			slog.String("BIOS", "CONIN"))
+		// Wait until the keyboard is ready to provide a character, and return it in A.
+		// Use our I/O package
+		obj := cpmio.New(cpm.Logger)
+
+		out, err := obj.BlockForCharacter()
+		if err != nil {
+			// record the error
+			cpm.ioErr = err
+			// halt processing.
+			cpm.CPU.HALT = true
+		}
+		cpm.CPU.States.AF.Hi = out
+
+	case 04:
+		cpm.Logger.Info("BIOS syscall 0x04",
+			slog.String("BIOS", "CONOUT"))
+
+		// Write the character in C to the screen.
+		c := cpm.CPU.States.BC.Lo
+		cpm.outC(c)
+	case 05:
+		cpm.Logger.Info("BIOS syscall 0x05",
+			slog.String("BIOS", "LIST"))
+
+		// Write the character in C to the printer
+		err := cpm.prnC(cpm.CPU.States.BC.Lo)
+		if err != nil {
+			// record the error
+			cpm.ioErr = err
+			// halt processing.
+			cpm.CPU.HALT = true
+		}
+
+	default:
+		cpm.Logger.Error("Unimplemented BIOS syscall",
+			slog.Int("syscall", int(val)),
+			slog.String("syscallHex", fmt.Sprintf("0x%02X", val)))
+	}
+}

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -7,6 +7,57 @@ import (
 	cpmio "github.com/skx/cpmulator/io"
 )
 
+// BiosSysCallBoot handles a warm/cold boot.
+func BiosSysCallBoot(cpm *CPM) error {
+
+	// Set entry-point to 0x0000 which will result in
+	// a boot-trap.
+	cpm.CPU.States.PC = 0x0000
+	return nil
+}
+
+// BiosSysCallConsoleStatus should return 0x00 if there is no input
+// pending, otherwise 0xFF.  We fake it
+func BiosSysCallConsoleStatus(cpm *CPM) error {
+	cpm.CPU.States.AF.Hi = 0x00
+
+	return nil
+}
+
+func BiosSysCallConsoleInput(cpm *CPM) error {
+
+	// Wait until the keyboard is ready to provide a character, and return it in A.
+	// Use our I/O package
+	obj := cpmio.New(cpm.Logger)
+
+	out, err := obj.BlockForCharacter()
+	if err != nil {
+		return err
+	}
+
+	cpm.CPU.States.AF.Hi = out
+	return nil
+}
+
+func BiosSysCallConsoleOutput(cpm *CPM) error {
+
+	// Write the character in C to the screen.
+	c := cpm.CPU.States.BC.Lo
+	cpm.outC(c)
+
+	return nil
+}
+
+func BiosSysCallPrintChar(cpm *CPM) error {
+
+	// Write the character in C to the printer
+	c := cpm.CPU.States.BC.Lo
+
+	// Write the character to the printer
+	err := cpm.prnC(c)
+	return err
+}
+
 // BiosHandler is involved when a BIOS syscall needs to be executed,
 // which is handled via trapping RST instructions and using a short
 // trampoline.
@@ -14,68 +65,24 @@ import (
 // The functions here are far fewer than those in the cpm_bdos.go files.
 func (cpm *CPM) BiosHandler(val uint8) {
 
-	switch val {
-	case 00:
-		cpm.Logger.Info("BIOS syscall 0x00",
-			slog.String("BIOS", "BOOT"))
+	// Lookup the handler
+	handler, ok := cpm.BIOSSyscalls[val]
 
-		// Set entry-point to 0x0000 which will result in
-		// a boot-trap.
-		cpm.CPU.States.PC = 0x0000
-	case 01:
-		cpm.Logger.Info("BIOS syscall 0x01",
-			slog.String("BIOS", "WBOOT"))
-
-		// Set entry-point to 0x0000 which will result in
-		// a boot-trap.
-		cpm.CPU.States.PC = 0x0000
-	case 02:
-		// Returns its status in A; 0 if no character is ready, 0FFh if one is.
-		cpm.Logger.Info("BIOS syscall 0x02",
-			slog.String("BIOS", "CONST"))
-
-		// Nothing pending - FAKE
-		cpm.CPU.States.AF.Hi = 0x00
-
-	case 03:
-		cpm.Logger.Info("BIOS syscall 0x03",
-			slog.String("BIOS", "CONIN"))
-		// Wait until the keyboard is ready to provide a character, and return it in A.
-		// Use our I/O package
-		obj := cpmio.New(cpm.Logger)
-
-		out, err := obj.BlockForCharacter()
-		if err != nil {
-			// record the error
-			cpm.ioErr = err
-			// halt processing.
-			cpm.CPU.HALT = true
-		}
-		cpm.CPU.States.AF.Hi = out
-
-	case 04:
-		cpm.Logger.Info("BIOS syscall 0x04",
-			slog.String("BIOS", "CONOUT"))
-
-		// Write the character in C to the screen.
-		c := cpm.CPU.States.BC.Lo
-		cpm.outC(c)
-	case 05:
-		cpm.Logger.Info("BIOS syscall 0x05",
-			slog.String("BIOS", "LIST"))
-
-		// Write the character in C to the printer
-		err := cpm.prnC(cpm.CPU.States.BC.Lo)
-		if err != nil {
-			// record the error
-			cpm.ioErr = err
-			// halt processing.
-			cpm.CPU.HALT = true
-		}
-
-	default:
+	// If it doesn't exist we don't have it implemented.
+	if !ok {
 		cpm.Logger.Error("Unimplemented BIOS syscall",
 			slog.Int("syscall", int(val)),
 			slog.String("syscallHex", fmt.Sprintf("0x%02X", val)))
+	}
+
+	// Otherwise invoke it, and look for any error
+	err := handler.Handler(cpm)
+
+	// If there was an error then record it for later notice.
+	if err != nil {
+		// record the error
+		cpm.ioErr = err
+		// halt processing.
+		cpm.CPU.HALT = true
 	}
 }

--- a/cpm/prnc.go
+++ b/cpm/prnc.go
@@ -1,0 +1,33 @@
+package cpm
+
+import (
+	"fmt"
+	"os"
+)
+
+// prnC attempts to write the character specified to the "printer".
+//
+// We redirect printing to use a file, which defaults to "print.log", but
+// which can be changed via the CLI argument
+func (cpm *CPM) prnC(char uint8) error {
+
+	// If the file doesn't exist, create it.
+	f, err := os.OpenFile(cpm.prnPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("prnC: Failed to open file %s:%s", cpm.prnPath, err)
+	}
+
+	data := make([]byte, 1)
+	data[0] = cpm.CPU.States.BC.Lo
+	_, err = f.Write(data)
+	if err != nil {
+		return fmt.Errorf("prnC: Failed to write to file %s:%s", cpm.prnPath, err)
+	}
+
+	err = f.Close()
+	if err != nil {
+		return fmt.Errorf("prnC: Failed to close file %s:%s", cpm.prnPath, err)
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -45,32 +45,44 @@ func main() {
 		// Create helper
 		c := cpm.New(nil, "print.log")
 
-		// Get syscalls in sorted order
+		// Get the BDOS syscalls in sorted order
 		ids := []int{}
-		for i := range c.Syscalls {
+		for i := range c.BDOSSyscalls {
 			ids = append(ids, int(i))
 		}
 		sort.Ints(ids)
 
+		// Now show them.
 		fmt.Printf("BDOS\n")
 		for id := range ids {
-			ent := c.Syscalls[uint8(id)]
+			ent := c.BDOSSyscalls[uint8(id)]
 			fake := ""
 			if ent.Fake {
 				fake = "FAKE"
 			}
 			fmt.Printf("\t%02d %-20s %s\n", int(id), ent.Desc, fake)
 		}
-		fmt.Printf("BIOS\n")
-		fmt.Printf("\t00  BOOT\n")
-		fmt.Printf("\t01  WBOOT\n")
-		fmt.Printf("\t02  CONST               FAKE\n")
-		fmt.Printf("\t03  CONIN\n")
-		fmt.Printf("\t04  CONOUT\n")
-		fmt.Printf("\t05  LIST\n")
 
+		// Get the BIOS syscalls in sorted order
+		ids = []int{}
+		for i := range c.BIOSSyscalls {
+			ids = append(ids, int(i))
+		}
+		sort.Ints(ids)
+
+		// Now show them.
+		fmt.Printf("BIOS\n")
+		for id := range ids {
+			ent := c.BIOSSyscalls[uint8(id)]
+			fake := ""
+			if ent.Fake {
+				fake = "FAKE"
+			}
+			fmt.Printf("\t%02d %-20s %s\n", int(id), ent.Desc, fake)
+		}
 		return
 	}
+
 	// Default program to execute, and arguments to pass to program
 	program := ""
 	args := []string{}

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func main() {
 		fmt.Printf("\t02  CONST               FAKE\n")
 		fmt.Printf("\t03  CONIN\n")
 		fmt.Printf("\t04  CONOUT\n")
+		fmt.Printf("\t05  LIST\n")
 
 		return
 	}


### PR DESCRIPTION
This pull-request implements the LIST bios call, number 5, which is supposed to write a single character to the printer.  In keeping with our previous implementing in the BDOS for the same purpose we write to a named file instead.

The common "print to file" code has been moved to a dedicated file, and I've broken out the BDOS and BIOS functions to named files to aid clarity:

* cpm_bdos.go - Contains BDOS functions.
* cpm_bios.go - Contains BIOS functions.

Hopefully that makes future confusion less likely.