### PR TITLE
Allow Ctrl-C to reboot, at the CCP

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -542,6 +542,8 @@ func (cpm *CPM) fixupRAM() {
 // and executed at a higher address than the default of 0x0100.
 func (cpm *CPM) LoadCCP(name string) error {
 
+	fmt.Printf("\n%c[2J%c[Hcpmulator loaded %s\n", 27, 27, name)
+
 	// Create 64K of memory, full of NOPs
 	if cpm.Memory == nil {
 		cpm.Memory = new(memory.Memory)
@@ -664,7 +666,6 @@ func (cpm *CPM) Execute(args []string) error {
 
 	// Run forever :)
 	for {
-
 		// Run until we hit an error
 		err := cpm.CPU.Run(context.Background())
 
@@ -744,6 +745,12 @@ func (cpm *CPM) Execute(args []string) error {
 		// Are we being asked to terminate CP/M?  If so return
 		if err == ErrExit {
 			return nil
+		}
+
+		// Are we to reboot?
+		if err == ErrBoot {
+			cpm.CPU.PC = 0x0000
+			continue
 		}
 
 		// Any other error is fatal.

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/skx/cpmulator/consolein"
 	"github.com/skx/cpmulator/fcb"
 )
 
@@ -174,6 +175,13 @@ func SysCallReadString(cpm *CPM) error {
 	text, err := cpm.input.ReadLine(max)
 
 	if err != nil {
+
+		// Ctrl-C pressed during input.
+		if err == consolein.ErrInterrupted {
+
+			// Reboot the system
+			return ErrBoot
+		}
 		return err
 	}
 


### PR DESCRIPTION
This pull-request close #82, by changing our ReadLine implementation to return a magic error if the user presses Ctrl-C twice in a row.

This then triggers a restart of the CCP.

This only works in the CCP, and in programs it launched.  If a user presses this combination otherwise it will terminate the emulation.

In a real CP/M system  Ctrl-C would reload, but it is too easy to accidentally press, so I ensure it is two consecuitive Ctrl-Cs that triggers this behaviour.