### PR TITLE
Fixed submit to work for > 2 commands

### DIFF
--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -492,7 +492,7 @@ func SysCallFileClose(cpm *CPM) error {
 
 		if hostExtent == seqEXT {
 			if int(fcbPtr.RC) < seqCR(hostSize) {
-				hostSize = int64(16384*seqEXT + int(128*fcbPtr.RC))
+				hostSize = int64(16384*seqEXT + int(128*int(fcbPtr.RC)))
 				err := obj.handle.Truncate(hostSize)
 				if err != nil {
 					return fmt.Errorf("error truncating file %s: %s", obj.name, err)


### PR DESCRIPTION
This pull-request closes #89 by fixing SUBMIT.COM to work for more than two commands - the bug was not casting the record-count out of a uint8 value (i.e. 8 bits) before multiplying by 128.

3 x 128 > 255, so the result was truncated and the file was truncated to the wrong size.

Stupid!