### PR TITLE
Simplify our embedding of the CCPs

### DIFF
--- a/ccp/ccp.go
+++ b/ccp/ccp.go
@@ -1,19 +1,24 @@
 // Package ccp contains a pair of embedded CCP binaries, which can
 // be used by the emulator as shells.
+//
+// At build-time we include "*.BIN" from the ccp/ directory, which
+// means it's easy to add a new CCP driver - however we must also
+// ensure there is a matching name-entry added to the code, so it isn't
+// 100% automatic.
 package ccp
 
 import (
-	_ "embed"
+	"embed"
 	"fmt"
 	"strings"
 )
 
-// ccps contains the global array of the CCP variants we have.
-var ccps []Flavour
-
 // Flavour contains details about a possible CCP the user might run.
 type Flavour struct {
 	// Name has the name of the CCP.
+	//
+	// NOTE: This name is visible to end-users, and will be used in the "-ccp" command-line flag,
+	// or as the name when changing at run-time via the "CCP.COM" utility.
 	Name string
 
 	// Description has the description of the CCP.
@@ -26,27 +31,34 @@ type Flavour struct {
 	Start uint16
 }
 
-//go:embed DR.BIN
-var ccpBin []uint8
+var (
+	// ccps contains the global array of the CCP variants we have.
+	ccps []Flavour
 
-//go:embed CCPZ.BIN
-var ccpzBin []uint8
+	//go:embed *.BIN
+	ccpFiles embed.FS
+)
 
 // init sets up our global ccp array, by adding the two embedded CCPs to
 // the array, with suitable names/offsets.
 func init() {
+
+	// Load the CCP from DR
+	ccp, _ := ccpFiles.ReadFile("DR.BIN")
 	ccps = append(ccps, Flavour{
 		Name:        "ccp",
-		Description: "CP/M v2.2",
+		Description: "CP/M v2.2skx",
 		Start:       0xDE00,
-		Bytes:       ccpBin,
+		Bytes:       ccp,
 	})
 
+	// Load the alternative CCP
+	ccpz, _ := ccpFiles.ReadFile("CCPZ.BIN")
 	ccps = append(ccps, Flavour{
 		Name:        "ccpz",
 		Description: "CCPZ v4.1skx",
 		Start:       0xDE00,
-		Bytes:       ccpzBin,
+		Bytes:       ccpz,
 	})
 }
 
@@ -57,13 +69,15 @@ func GetAll() []Flavour {
 
 // Get returns the CCP version specified, by name, if it exists.
 //
-// If the given name is invalid then an error will be returned.
+// If the given name is invalid then an error will be returned instead.
 func Get(name string) (Flavour, error) {
 
 	valid := []string{}
 
 	for _, ent := range ccps {
 
+		// When changing at runtime, via "CCP.COM", we will have had
+		// the name upper-cased by the CCP so we need to downcase here.
 		if strings.ToLower(name) == ent.Name {
 			return ent, nil
 		}

--- a/ccp/ccp_test.go
+++ b/ccp/ccp_test.go
@@ -21,7 +21,7 @@ func TestCCPTrivial(t *testing.T) {
 
 		// The CCPs are small, but bigger than 1k and smaller than 8k
 		if len(bytes) < 1024 {
-			t.Fatalf("CCP %s is too small", n.Name)
+			t.Fatalf("CCP %s is too small got %d bytes", n.Name, len(bytes))
 		}
 
 		if len(bytes) > 8192 {

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -220,6 +220,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		} else {
 			cpm.input.SetInterruptCount(int(c))
 		}
+
 	case 0x0002:
 		str := ""
 
@@ -249,6 +250,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		} else {
 			fmt.Printf("console driver is already %s, making no change.\n", str)
 		}
+
 	case 0x0003:
 		str := ""
 
@@ -263,7 +265,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		str = strings.ToLower(str)
 
 		// See if the CCP exists
-		_, err := ccp.Get(str)
+		entry, err := ccp.Get(str)
 		if err != nil {
 			fmt.Printf("Invalid CCP name %s\n", str)
 			return nil
@@ -273,11 +275,12 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		old := cpm.ccp
 
 		if old != str {
-			fmt.Printf("CCP changed from %s to %s.\n", old, str)
+			fmt.Printf("CCP changed to %s [%s] Size:0x%04X Entry-Point:0x%04X\n", str, entry.Description, len(entry.Bytes), entry.Start)
 			cpm.ccp = str
 		} else {
 			fmt.Printf("CCP is already %s, making no change.\n", str)
 		}
+
 	case 0x0004:
 		if c == 0x00 {
 			cpm.quiet = true

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -244,9 +244,15 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		}
 
 		old := cpm.output.GetName()
+		cpm.output = driver
+
+		// when running quietly don't show any output
+		if cpm.quiet {
+			return nil
+		}
+
 		if old != str {
 			fmt.Printf("Console driver changed from %s to %s.\n", cpm.output.GetName(), driver.GetName())
-			cpm.output = driver
 		} else {
 			fmt.Printf("console driver is already %s, making no change.\n", str)
 		}
@@ -273,10 +279,15 @@ func BiosSysCallReserved1(cpm *CPM) error {
 
 		// old value
 		old := cpm.ccp
+		cpm.ccp = str
+
+		// when running quietly don't show any output
+		if cpm.quiet {
+			return nil
+		}
 
 		if old != str {
 			fmt.Printf("CCP changed to %s [%s] Size:0x%04X Entry-Point:0x%04X\n", str, entry.Description, len(entry.Bytes), entry.Start)
-			cpm.ccp = str
 		} else {
 			fmt.Printf("CCP is already %s, making no change.\n", str)
 		}


### PR DESCRIPTION
We now install "*.BIN" in our binary, rather than having two dedicated entries.  This makes things simpler, but still not 100% automatic as we still need to add an entry to the "Flavour" list when adding a new one.