### PR TITLE
Added CLI flag for controlling quiet-behaviour

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -443,6 +443,16 @@ func (cpm *CPM) GetCCPName() string {
 	return cpm.ccp
 }
 
+// GetQuiet returns the status of the quiet-flag.
+func (cpm *CPM) GetQuiet() bool {
+	return cpm.quiet
+}
+
+// SetQuiet updates the state of the quiet-flag.
+func (cpm *CPM) SetQuiet(state bool) {
+	cpm.quiet = state
+}
+
 // LoadBinary loads the given CP/M binary at the default address of 0x0100,
 // where it can then be launched by Execute.
 func (cpm *CPM) LoadBinary(filename string) error {
@@ -570,7 +580,7 @@ func (cpm *CPM) fixupRAM() {
 func (cpm *CPM) LoadCCP() error {
 
 	// Show a startup-banner.
-	if !cpm.quiet {
+	if !cpm.GetQuiet() {
 		fmt.Printf("\ncpmulator %s loaded CCP %s, with %s output driver\n", cpmver.GetVersionString(), cpm.GetCCPName(), cpm.GetOutputDriver())
 	}
 

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -300,11 +300,9 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		}
 
 	case 0x0004:
-		if c == 0x00 {
-			cpm.quiet = true
-		} else {
-			cpm.quiet = false
-		}
+
+		// Set the quiet flag
+		cpm.SetQuiet(c == 0x00)
 
 	default:
 		fmt.Printf("Unknown custom BIOS function HL:%04X, ignoring", hl)

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func main() {
 	logPath := flag.String("log-path", "", "Specify the file to write debug logs to.")
 	prnPath := flag.String("prn-path", "print.log", "Specify the file to write printer-output to.")
 	syscalls := flag.Bool("syscalls", false, "List the syscalls we implement.")
+	quiet := flag.Bool("quiet", false, "Avoid showing the startup-banner when CCP is reloaded.")
 	showVersion := flag.Bool("version", false, "Report our version, and exit.")
 	flag.Parse()
 
@@ -139,6 +140,11 @@ func main() {
 	if err != nil {
 		fmt.Printf("error creating CPM object: %s\n", err)
 		return
+	}
+
+	// Set the quiet behaviour
+	if *quiet {
+		obj.SetQuiet(*quiet)
 	}
 
 	// When we're finishing we'll reset some (console) state.


### PR DESCRIPTION
This pull-request closes #95, by allowing the quiet-flag to be set at the start.

Otherwise we have to rely upon the user running `QUIET.COM` (from beneath `samples/`, or included in the cpm-dist repository).