### PR TITLE
Allow running AUTOEXEC.SUB on-startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,24 @@ Other options are shown in the output of `cpmulator -help`, but in brief:
   * Output debug-logs to the given file, creating it if necessary.
 * `-prn-path /path/to/file`
   * All output which CP/M sends to the "printer" will be written to the given file.
+* `-quiet`
+  * Enable quiet-mode, which cuts down on output.
 * `-syscalls`
   * Dump the list of implemented BDOS and BIOS syscalls.
 * `-version`
   * Show our version number.
+
+
+
+## Startup Processing
+
+When the CCP is launched for interactive execution, we allow commands to be executed at startup:
+
+* If `SUBMIT.COM` **and** `AUTOEXEC.SUB` exist on A:
+* Then the contents of `AUTOEXEC.SUB` will be executed.
+* We secretly run "`SUBMIT AUTOEXEC`" to achieve this.
+
+This allows you to customize the emulator, or perform other "one-time" setup via the options described in the next section.
 
 
 

--- a/main.go
+++ b/main.go
@@ -242,6 +242,11 @@ func main() {
 		return
 	}
 
+	// We will load AUTOEXEC.SUB, once, if it exists (*)
+	//
+	// * - Terms and conditions apply.
+	autoexec := false
+
 	// We load and re-run eternally - because many binaries the CCP
 	// would launch would end with "exit" which would otherwise cause
 	// our emulation to terminate
@@ -250,6 +255,13 @@ func main() {
 	// just jump back to the entry-point for that.
 	//
 	for {
+
+		// Run the autoexec behaviour, once only
+		if !autoexec {
+			obj.RunAutoExec()
+			autoexec = true
+		}
+
 		// Load the CCP binary - resetting RAM in the process.
 		err := obj.LoadCCP()
 		if err != nil {


### PR DESCRIPTION
If the following files exist:

* A:SUBMIT.COM
* A:AUTOEXEC.SUB

Then

* On-startup the text "SUBMIT AUTOEXEC" is forced into the input-buffer that the CCP will read from.
* This has the effect of ensuring that the AUTOEXEC.SUB file is executed.

This behaviour is only executed once, to avoid an infinite loop.

This closes #96.