### PR TITLE
Always use drive-remapping (internally)

### DIFF
--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -199,11 +199,11 @@ func BiosSysCallReserved1(cpm *CPM) error {
 	//
 	getStringFromMemory := func(addr uint16) string {
 		str := ""
-		c := cpm.Memory.Get(addr)
-		for c != ' ' && c != 0x00 {
-			str += string(c)
+		x := cpm.Memory.Get(addr)
+		for x != ' ' && x != 0x00 {
+			str += string(x)
 			addr++
-			c = cpm.Memory.Get(addr)
+			x = cpm.Memory.Get(addr)
 		}
 
 		// Useful when the CCP has passed a string, because

--- a/main.go
+++ b/main.go
@@ -173,10 +173,13 @@ func main() {
 		}
 	}
 
+	// Default to not using subdirectories for drives
+	obj.SetDrives(false)
+
 	// Are we using drives?
 	if *useDirectories {
 
-		// Enable drives
+		// Enable the use of directories.
 		obj.SetDrives(true)
 
 		// Count how many drives exist - if zero show a warning


### PR DESCRIPTION
Rather than conditionally using subdirectories as drives, we now just do that always.  If drives are in use then we have amapping:

* A: -> A/
* B: -> B/
* etc

If they are not?

* A: -> .
* B: -> .
* etc

That means we can always use our lookup table (i.e. map) to know where to look for things and don't need to have special cases.

This closes #101.