### PR TITLE
Persist the usernumber across restarts

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -544,9 +544,6 @@ func (cpm *CPM) fixupRAM() {
 	// Now we setup the initial values of the I/O byte
 	SETMEM(0x0003, 0x00)
 
-	// Finally the current drive and usernumber.
-	SETMEM(0x0004, 0x00)
-
 	// fake BIOS entry points for 30 syscalls.
 	//
 	// These are setup so that the RST instructions magically
@@ -669,7 +666,10 @@ func (cpm *CPM) Execute(args []string) error {
 	// this processing object - so drive-changes will update that
 	// value from the default when it is changed.
 	//
-	cpm.CPU.States.BC.Lo = cpm.currentDrive
+	cpm.CPU.States.BC.Lo = cpm.userNumber<<4 | cpm.currentDrive
+
+	// Set the same value in RAM
+	cpm.Memory.Set(0x0004, cpm.CPU.States.BC.Lo)
 
 	// Setup our breakpoints.
 	//

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -261,9 +261,11 @@ func SysCallSetDMA(cpm *CPM) error {
 // which will be read by the CCP - as created by SUBMIT.COM
 func SysCallDriveAllReset(cpm *CPM) error {
 
-	// Reset disk and user-number
+	// Reset disk - but leave the user-number alone
 	cpm.currentDrive = 0
-	cpm.userNumber = 0
+
+	// Update RAM
+	cpm.Memory.Set(0x0004, (cpm.userNumber<<4 | cpm.currentDrive))
 
 	// Default return value
 	var ret uint8 = 0
@@ -312,7 +314,7 @@ func SysCallDriveSet(cpm *CPM) error {
 	cpm.currentDrive = drv
 
 	// Update RAM
-	cpm.Memory.Set(0x0004, cpm.currentDrive)
+	cpm.Memory.Set(0x0004, (cpm.userNumber<<4 | cpm.currentDrive))
 
 	// Return values:
 	// HL = 0, B=0, A=0
@@ -1151,6 +1153,9 @@ func SysCallUserNumber(cpm *CPM) error {
 
 		// Set the number - masked, because valid values are 0-15
 		cpm.userNumber = (cpm.CPU.States.DE.Lo & 0x0F)
+
+		// Update RAM
+		cpm.Memory.Set(0x0004, (cpm.userNumber<<4 | cpm.currentDrive))
 	}
 
 	// Return values:


### PR DESCRIPTION
This pull-request closes #108 by persisting the state of the user-number as well as the current-drive which we previously handled.

User-numbers are something that most people don't seem to care about, but we should do things at least a little properly.