### PR TITLE
Allow DDT.COM to run

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -671,6 +671,9 @@ func (cpm *CPM) Execute(args []string) error {
 	// Set the same value in RAM
 	cpm.Memory.Set(0x0004, cpm.CPU.States.BC.Lo)
 
+	CBIOS := uint16(0xFE00)
+	BDOS := uint16(0xF000)
+
 	// Setup our breakpoints.
 	//
 	// We configure two:
@@ -679,7 +682,10 @@ func (cpm *CPM) Execute(args []string) error {
 	//  0x0005 - The CPM BDOS entrypoint.
 	//
 	cpm.CPU.BreakPoints = make(map[uint16]struct{})
-	cpm.CPU.BreakPoints[0x0000] = struct{}{}
+	cpm.CPU.BreakPoints[CBIOS] = struct{}{}
+	cpm.CPU.BreakPoints[CBIOS+3] = struct{}{}
+	cpm.CPU.BreakPoints[BDOS] = struct{}{}
+	cpm.CPU.BreakPoints[BDOS+6] = struct{}{}
 	cpm.CPU.BreakPoints[0x0005] = struct{}{}
 
 	// Convert our array of CLI arguments to a string.
@@ -834,8 +840,12 @@ func (cpm *CPM) RunAutoExec() {
 		// Add the name
 		dst := filepath.Join(prefix, name)
 
+		// Open it to see if it exists.
 		handle, err := os.OpenFile(dst, os.O_RDONLY, 0644)
 		if err != nil {
+
+			// We're assuming "file not found",
+			// or similar, here.
 			return
 		}
 

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -495,7 +495,10 @@ func SysCallFileClose(cpm *CPM) error {
 	// Get the file handle from our cache.
 	obj, ok := cpm.files[ptr]
 	if !ok {
-		return fmt.Errorf("tried to close a file that wasn't open")
+		cpm.Logger.Debug("SysCallFileClose tried to close a file that wasn't open",
+			slog.Int("fcb", int(ptr)))
+		cpm.CPU.States.AF.Hi = 0x00
+		return nil
 	}
 
 	// Close of a virtual file.


### PR DESCRIPTION
This was an interesting case to track down, it seems that DDT is special - it loads and copies itself elsewhere in RAM, then it updates the jump tables at the zero-page.

The end result is that it can get re'execd when it needs to do things.

Because I had a breakpoint set on 0x0000 (i.e. coldboot) I was getting trapped when DDT should have been re-invoked.  I think that changing the traps to the default address we pretend BIOS/BDOS are located is enough to make it run, and simple execution seems to work.

Compiling a simple binary:

```
A>
A>asm hello
CP/M ASSEMBLER - VER 2.0
011B
000H USE FACTOR
END OF ASSEMBLY

A>load hello

FIRST ADDRESS 0100
LAST  ADDRESS 011A
BYTES READ    001B
RECORDS WRITTEN 01
```

Loading a simple binary:

```
A>ddt hello.com
DDT VERS 2.2
NEXT  PC
0180 0100
-d0100
0100 0E 09 11 09 01 CD 05 00 C9 0D 0A 48 65 6C 6C 6F ...........Hello
0110 2C 20 57 6F 72 6C 64 21 0D 0A 24 00 00 00 00 00 , World!..$.....
0120 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
0130 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
0140 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
0150 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
0160 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
0170 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
0180 1A 84 12 13 C3 69 01 D1 2E 00 E9 0E 10 CD 05 00 .....i..........
0190 32 5F 1E C9 21 66 1E 70 2B 71 2A 65 1E EB 0E 11 2_..!f.p+q*e....
01A0 CD 05 00 32 5F 1E C9 11 00 00 0E 12 CD 05 00 32 ...2_..........2
01B0 5F 1E C9 21 68 1E 70 2B 71 2A 67 1E EB 0E 13 CD _..!h.p+q*g.....
-L0100 0108
  0100  MVI  C,09
  0102  LXI  D,0109
  0105  CALL 0005
  0108  RET
-T2
C0Z0M0E0I0 A=00 B=0000 D=0000 H=0000 S=0100 P=0100 MVI  C,09
C0Z0M0E0I0 A=00 B=0009 D=0000 H=0000 S=0100 P=0102 LXI  D,0109*0105
-t
C0Z0M0E0I0 A=00 B=0009 D=0109 H=0000 S=0100 P=0105 CALL 0005
Hello, World!
```

Seems like we get stuck here, but dump/assemble/list work.  We'll pretend that's enough.