### PR TITLE
Added test-coverage for the console output functions

### DIFF
--- a/consoleout/console_ansi.go
+++ b/consoleout/console_ansi.go
@@ -1,9 +1,15 @@
 package consoleout
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+	"os"
+)
 
 // AnsiOutputDriver holds our state.
 type AnsiOutputDriver struct {
+	// writer is where we send our output
+	writer io.Writer
 }
 
 // GetName returns the name of this driver.
@@ -17,12 +23,19 @@ func (ad *AnsiOutputDriver) GetName() string {
 //
 // This is part of the OutputDriver interface.
 func (ad *AnsiOutputDriver) PutCharacter(c uint8) {
-	fmt.Printf("%c", c)
+	fmt.Fprintf(ad.writer, "%c", c)
+}
+
+// SetWriter will update the writer.
+func (ad *AnsiOutputDriver) SetWriter(w io.Writer) {
+	ad.writer = w
 }
 
 // init registers our driver, by name.
 func init() {
 	Register("ansi", func() ConsoleDriver {
-		return &AnsiOutputDriver{}
+		return &AnsiOutputDriver{
+			writer: os.Stdout,
+		}
 	})
 }

--- a/consoleout/console_null.go
+++ b/consoleout/console_null.go
@@ -1,0 +1,43 @@
+package consoleout
+
+import (
+	"io"
+	"os"
+)
+
+// NullOutputDriver holds our state.
+type NullOutputDriver struct {
+
+	// writer is where we send our output
+	writer io.Writer
+}
+
+// GetName returns the name of this driver.
+//
+// This is part of the OutputDriver interface.
+func (no *NullOutputDriver) GetName() string {
+	return "null"
+}
+
+// PutCharacter writes the specified character to the console,
+// as this is a null-driver nothing happens and instead the output
+// is discarded.
+//
+// This is part of the OutputDriver interface.
+func (n *NullOutputDriver) PutCharacter(c uint8) {
+	// NOTHING HAppens
+}
+
+// SetWriter will update the writer.
+func (n *NullOutputDriver) SetWriter(w io.Writer) {
+	n.writer = w
+}
+
+// init registers our driver, by name.
+func init() {
+	Register("null", func() ConsoleDriver {
+		return &NullOutputDriver{
+			writer: os.Stdout,
+		}
+	})
+}

--- a/consoleout/console_test.go
+++ b/consoleout/console_test.go
@@ -1,6 +1,9 @@
 package consoleout
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 // TestName ensures we can lookup a driver by name
 func TestName(t *testing.T) {
@@ -50,5 +53,59 @@ func TestChangeDriver(t *testing.T) {
 	}
 	if ansi.GetName() != "adm-3a" {
 		t.Fatalf("driver changed unexpectedly")
+	}
+}
+
+// TestOutput ensures that our two "real" drivers output, as expected
+func TestOutput(t *testing.T) {
+
+	// Drivers that should produce output
+	valid := []string{"ansi", "adm-3a"}
+
+	for _, nm := range valid {
+
+		d, e := New(nm)
+		if e != nil {
+			t.Fatalf("failed to lookup driver by name %s:%s", nm, e)
+		}
+
+		// ensure we redirect the output
+		tmp := &bytes.Buffer{}
+
+		d.driver.SetWriter(tmp)
+
+		for _, c := range "Steve Kemp" {
+			d.PutCharacter(byte(c))
+		}
+
+		// Test we got the output we expected
+		if tmp.String() != "Steve Kemp" {
+			t.Fatalf("output driver %s produced '%s'", d.GetName(), tmp.String())
+		}
+	}
+
+}
+
+// TestNull ensures nothing is written by the null output driver
+func TestNull(t *testing.T) {
+
+	// Start with a known-good driver
+	null, err := New("null")
+	if err != nil {
+		t.Fatalf("failed to load starting driver %s", err)
+	}
+	if null.GetName() != "null" {
+		t.Fatalf("null driver has the wrong name")
+	}
+
+	// ensure we redirect the output
+	tmp := &bytes.Buffer{}
+
+	null.driver.SetWriter(tmp)
+
+	null.PutCharacter('s')
+
+	if tmp.String() != "" {
+		t.Fatalf("got output, expected none: '%s'", tmp.String())
 	}
 }

--- a/consoleout/consoleout.go
+++ b/consoleout/consoleout.go
@@ -5,7 +5,10 @@
 // given just a name.
 package consoleout
 
-import "fmt"
+import (
+	"fmt"
+	"io"
+)
 
 // ConsoleDriver is the interface that must be implemented by anything
 // that wishes to be used as a console driver.
@@ -19,6 +22,9 @@ type ConsoleDriver interface {
 
 	// GetName will return the name of the driver.
 	GetName() string
+
+	// SetWriter will update the writer
+	SetWriter(io.Writer)
 }
 
 // This is a map of known-drivers

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -119,7 +119,7 @@ type CPM struct {
 	input *consolein.ConsoleIn
 
 	// output is used for writing characters to the conolse
-	output consoleout.ConsoleDriver
+	output *consoleout.ConsoleOut
 
 	// dma contains the address of the DMA area in RAM.
 	//

--- a/static/static_test.go
+++ b/static/static_test.go
@@ -1,0 +1,24 @@
+package static
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStatic just ensures we have some files.
+func TestStatic(t *testing.T) {
+
+	// Read the subdirectory
+	files, err := Content.ReadDir("A")
+	if err != nil {
+		t.Fatalf("error reading contents")
+	}
+
+	// Ensure each file is a .COM files
+	for _, entry := range files {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".COM") {
+			t.Fatalf("file '%s' is not a .COM file", name)
+		}
+	}
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,17 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestVersion is a nop-test that performs coverage of our version package.
+func TestVersion(t *testing.T) {
+	x := GetVersionString()
+	y := GetVersionBanner()
+
+	// Banner should have our version
+	if !strings.Contains(y, x) {
+		t.Fatalf("banner doesn't contain our version")
+	}
+}


### PR DESCRIPTION
We've not added complete tests for the ADM-3A driver, but we've added enough to prove it works - by allowing output to be redirected we can test it does the right kinda thing.