### PR TITLE
Don't log console I/O functions, by default

### DIFF
--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -362,23 +362,25 @@ func (cpm *CPM) BiosHandler(val uint8) {
 		return
 	}
 
-	// Log the call we're going to make
-	cpm.Logger.Info("BIOS",
-		slog.String("name", handler.Desc),
-		slog.Int("syscall", int(val)),
-		slog.String("syscallHex", fmt.Sprintf("0x%02X", val)),
-		slog.Group("registers",
-			slog.String("A", fmt.Sprintf("%02X", cpm.CPU.States.AF.Hi)),
-			slog.String("B", fmt.Sprintf("%02X", cpm.CPU.States.BC.Hi)),
-			slog.String("C", fmt.Sprintf("%02X", cpm.CPU.States.BC.Lo)),
-			slog.String("D", fmt.Sprintf("%02X", cpm.CPU.States.DE.Hi)),
-			slog.String("E", fmt.Sprintf("%02X", cpm.CPU.States.DE.Lo)),
-			slog.String("F", fmt.Sprintf("%02X", cpm.CPU.States.AF.Lo)),
-			slog.String("H", fmt.Sprintf("%02X", cpm.CPU.States.HL.Hi)),
-			slog.String("L", fmt.Sprintf("%02X", cpm.CPU.States.HL.Lo)),
-			slog.String("BC", fmt.Sprintf("%04X", cpm.CPU.States.BC.U16())),
-			slog.String("DE", fmt.Sprintf("%04X", cpm.CPU.States.DE.U16())),
-			slog.String("HL", fmt.Sprintf("%04X", cpm.CPU.States.HL.U16()))))
+	if !handler.Noisy {
+		// Log the call we're going to make
+		cpm.Logger.Info("BIOS",
+			slog.String("name", handler.Desc),
+			slog.Int("syscall", int(val)),
+			slog.String("syscallHex", fmt.Sprintf("0x%02X", val)),
+			slog.Group("registers",
+				slog.String("A", fmt.Sprintf("%02X", cpm.CPU.States.AF.Hi)),
+				slog.String("B", fmt.Sprintf("%02X", cpm.CPU.States.BC.Hi)),
+				slog.String("C", fmt.Sprintf("%02X", cpm.CPU.States.BC.Lo)),
+				slog.String("D", fmt.Sprintf("%02X", cpm.CPU.States.DE.Hi)),
+				slog.String("E", fmt.Sprintf("%02X", cpm.CPU.States.DE.Lo)),
+				slog.String("F", fmt.Sprintf("%02X", cpm.CPU.States.AF.Lo)),
+				slog.String("H", fmt.Sprintf("%02X", cpm.CPU.States.HL.Hi)),
+				slog.String("L", fmt.Sprintf("%02X", cpm.CPU.States.HL.Lo)),
+				slog.String("BC", fmt.Sprintf("%04X", cpm.CPU.States.BC.U16())),
+				slog.String("DE", fmt.Sprintf("%04X", cpm.CPU.States.DE.U16())),
+				slog.String("HL", fmt.Sprintf("%04X", cpm.CPU.States.HL.U16()))))
+	}
 
 	// Otherwise invoke it, and look for any error
 	err := handler.Handler(cpm)

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func main() {
 	ccps := flag.Bool("ccps", false, "Dump the list of embedded CCPs.")
 	useDirectories := flag.Bool("directories", false, "Use subdirectories on the host computer for CP/M drives.")
 	logPath := flag.String("log-path", "", "Specify the file to write debug logs to.")
+	logAll := flag.Bool("log-all", false, "Log the output of all functions, including the noisy Console I/O ones.")
 	prnPath := flag.String("prn-path", "print.log", "Specify the file to write printer-output to.")
 	syscalls := flag.Bool("syscalls", false, "List the syscalls we implement.")
 	quiet := flag.Bool("quiet", false, "Avoid showing the startup-banner when CCP is reloaded.")
@@ -161,6 +162,11 @@ func main() {
 	if err != nil {
 		fmt.Printf("error creating CPM object: %s\n", err)
 		return
+	}
+
+	// Are we logging noisy functions?
+	if *logAll {
+		obj.LogNoisy()
 	}
 
 	// Set the quiet behaviour


### PR DESCRIPTION
The new flag "-log-all" will ensure their output is shown, but dropped otherwise.  This should make cleaner logs, and ease debugging.

This closes #130.