### PR TITLE
Allow BBC BASIC to run

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -366,6 +366,13 @@ func New(logger *slog.Logger, prn string, condriver string, ccp string) (*CPM, e
 		Handler: BdosSysCallDriveReset,
 		Fake:    true,
 	}
+	bdos[40] = CPMHandler{
+		Desc:    "F_WRITEZF",
+		Handler: BdosSysCallWriteRand,
+
+		// We don't zero-pad
+		Fake: true,
+	}
 	bdos[45] = CPMHandler{
 		Desc:    "F_ERRMODE",
 		Handler: BdosSysCallErrorMode,


### PR DESCRIPTION
BBC BASIC is an interesting dialect, because it has a built-in assembler, and allows *DIR, *TYPE, and more to be executed.

Documentation is good, the program is reasonably robust.  By default it was doing some weird thing where it expected the zero-flag to be set as a result of CP/M calls - so I had to patch it to avoid that.

The binary was added to cpm-dist:

* https://github.com/skx/cpm-dist
  * Via my fork of the patched source
  * https://github.com/skx/bbcbasic-z80

The only actual change I had to make here was to implement function 40, F_WRITEZF, which I faked via the existing function.

This closes #129, allowing the BASIC to run and load/save binaries.