### PR TITLE
Added more tests - fixed issue with using CPU.Memory

### DIFF
--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -227,7 +227,7 @@ func BdosSysCallReadString(cpm *CPM) error {
 	}
 
 	// First byte is the max len
-	max := cpm.CPU.Memory.Get(addr)
+	max := cpm.Memory.Get(addr)
 
 	// read the input
 	text, err := cpm.input.ReadLine(max)
@@ -245,12 +245,12 @@ func BdosSysCallReadString(cpm *CPM) error {
 
 	// addr[0] is the size of the input buffer
 	// addr[1] should be the size of input read, set it:
-	cpm.CPU.Memory.Set(addr+1, uint8(len(text)))
+	cpm.Memory.Set(addr+1, uint8(len(text)))
 
 	// addr[2+] should be the text
 	i := 0
 	for i < len(text) {
-		cpm.CPU.Memory.Set(uint16(addr+2+uint16(i)), text[i])
+		cpm.Memory.Set(uint16(addr+2+uint16(i)), text[i])
 		i++
 	}
 

--- a/cpm/cpm_bdos_test.go
+++ b/cpm/cpm_bdos_test.go
@@ -5,9 +5,53 @@ import (
 	"os"
 	"testing"
 
+	"github.com/skx/cpmulator/consolein"
 	"github.com/skx/cpmulator/fcb"
 	"github.com/skx/cpmulator/memory"
 )
+
+func TestReadLine(t *testing.T) {
+
+	// Create a new helper
+	c, err := New()
+	if err != nil {
+		t.Fatalf("failed to create CPM")
+	}
+	c.Memory = new(memory.Memory)
+
+	// Stuff some fake input
+	c.input = consolein.New()
+	c.input.StuffInput("steve")
+
+	// Setup a buffer, so we can read 5 characters
+	c.Memory.Set(0x0100, 5)
+	c.CPU.States.DE.SetU16(0x0100)
+
+	// Read it
+	err = BdosSysCallReadString(c)
+	if err != nil {
+		t.Fatalf("error reading CPM")
+	}
+
+	// How much did we get
+	got := c.Memory.Get(0x0101)
+	if got != 05 {
+		t.Fatalf("returned wrong amount")
+	}
+
+	// What did we get?
+	text := ""
+	i := 0
+	for i < int(got) {
+		text += string(c.Memory.Get(uint16(0x0102 + i)))
+		i++
+	}
+
+	if text != "steve" {
+		t.Fatalf("wrong text received")
+	}
+
+}
 
 func TestDriveGetSet(t *testing.T) {
 


### PR DESCRIPTION
We used CPU.Memory rather than cpm.Memory, accidentally, in the readstring function - but this was harmless.  Fixed anyway.