### PR TITLE
Increased test-coverage once-again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	github.com/koron-go/z80 v0.10.1
-	golang.org/x/term v0.21.0
+	golang.org/x/term v0.22.0
 )
 
 require golang.org/x/sys v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,5 @@ github.com/koron-go/z80 v0.10.1 h1:Jfb0esP/QFL4cvcr+eFECVG0Y/mA9JBLC4EKbMU5zAY=
 github.com/koron-go/z80 v0.10.1/go.mod h1:ry+Zl9kRKelzaDG9UzEtUpUnXy0Yv/kk1YEaX958xdk=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
 golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.21.0 h1:WVXCp+/EBEHOj53Rvu+7KiT/iElMrO8ACK16SMZ3jaA=
-golang.org/x/term v0.21.0/go.mod h1:ooXLefLobQVslOqselCNF4SxFAaoS6KujMbsGzSDmX0=
+golang.org/x/term v0.22.0 h1:BbsgPEJULsl2fV/AT3v15Mjva5yXKQDyKf+TbDz7QJk=
+golang.org/x/term v0.22.0/go.mod h1:F3qCibpT5AMpCRfhfT53vVJwhLtIVHhB9XDjfFvnMI4=

--- a/main.go
+++ b/main.go
@@ -216,8 +216,7 @@ func main() {
 	}
 
 	// Load any embedded files within our binary
-	files := static.Content
-	obj.SetStaticFilesystem(files)
+	obj.SetStaticFilesystem(static.GetContent())
 
 	// Default to not using subdirectories for drives
 	obj.SetDrives(false)

--- a/static/static.go
+++ b/static/static.go
@@ -8,4 +8,9 @@ package static
 import "embed"
 
 //go:embed */*
-var Content embed.FS
+var content embed.FS
+
+// GetContent returns the embedded filesystem we store within this package.
+func GetContent() embed.FS {
+	return content
+}

--- a/static/static_test.go
+++ b/static/static_test.go
@@ -9,7 +9,7 @@ import (
 func TestStatic(t *testing.T) {
 
 	// Read the subdirectory
-	files, err := Content.ReadDir("A")
+	files, err := GetContent().ReadDir("A")
 	if err != nil {
 		t.Fatalf("error reading contents")
 	}


### PR DESCRIPTION
FCB is now at 100%.  Other stuff looks good:

```
$ cover ./...
	github.com/skx/cpmulator/consolein		coverage: 0.0% of statements
	github.com/skx/cpmulator		coverage: 0.0% of statements
ok  	github.com/skx/cpmulator/ccp	0.003s	coverage: 100.0% of statements
ok  	github.com/skx/cpmulator/consoleout	0.004s	coverage: 40.7% of statements
ok  	github.com/skx/cpmulator/cpm	0.182s	coverage: 64.4% of statements
ok  	github.com/skx/cpmulator/fcb	0.005s	coverage: 100.0% of statements
ok  	github.com/skx/cpmulator/memory	0.005s	coverage: 100.0% of statements
ok  	github.com/skx/cpmulator/static	0.005s	coverage: 100.0% of statements
ok  	github.com/skx/cpmulator/version	0.003s	coverage: 100.0% of statements
```

Biggest issue is the console-input tests are missing.  Not sure what to do about those - make the stuffed input work there too?  Or something else?