### PR TITLE
Implement support for the RunCPM-Specific function F_UPTIME

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/koron-go/z80"
 	"github.com/skx/cpmulator/ccp"
@@ -189,6 +190,9 @@ type CPM struct {
 	// For real debugging we expect the caller to use our Logger, via
 	// the logfile
 	simpleDebug bool
+
+	// launchTime is the time at which the application was launched
+	launchTime time.Time
 }
 
 // ccpoption defines a config-setting option for our constructor.
@@ -426,6 +430,11 @@ func New(options ...cpmoption) (*CPM, error) {
 		Handler: BdosSysCallDirectScreenFunctions,
 		Fake:    true,
 	}
+	bdos[248] = CPMHandler{ // used by BBC BASIC v5
+		Desc:    "F_UPTIME",
+		Handler: BdosSysCallUptime,
+		Fake:    true,
+	}
 
 	//
 	// Create and populate our syscall table for the BIOS syscalls.
@@ -504,6 +513,7 @@ func New(options ...cpmoption) (*CPM, error) {
 		output:       driver,        // default
 		prnPath:      "printer.log", // default
 		start:        0x0100,
+		launchTime:   time.Now(),
 	}
 
 	// Allow options to override our defaults

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/skx/cpmulator/consolein"
 	"github.com/skx/cpmulator/fcb"
@@ -1673,5 +1674,24 @@ func BdosSysCallTime(cpm *CPM) error {
 // which specifies which function to run.  I've only seen this invoked in
 // TurboPascal when choosing the "Execute" or "Run" options.
 func BdosSysCallDirectScreenFunctions(cpm *CPM) error {
+	return nil
+}
+
+// BdosSysCallUptime returns the number of "ticks" since the system
+// was booted, it is a custom syscall which is implemented by RunCPM
+// which we implement for compatibility, notable users include v5
+// of BBC BASIC.
+func BdosSysCallUptime(cpm *CPM) error {
+
+	// Get elapsed time, since startup
+	elapsed := time.Since(cpm.launchTime)
+
+	// In nanoseconds
+	timer := elapsed.Nanoseconds()
+
+	// Set it.
+	cpm.CPU.States.HL.SetU16(uint16(timer & 0xFFFF))
+	cpm.CPU.States.DE.SetU16(uint16((timer >> 16) & 0xFFFF))
+
 	return nil
 }

--- a/cpm/cpm_bdos_test.go
+++ b/cpm/cpm_bdos_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/skx/cpmulator/consolein"
 	"github.com/skx/cpmulator/fcb"
@@ -1285,4 +1286,40 @@ func TestRead(t *testing.T) {
 		t.Fatalf("read rand (virtual) failed")
 	}
 
+}
+
+func TestTicks(t *testing.T) {
+
+	// Create a new helper
+	c, err := New()
+	if err != nil {
+		t.Fatalf("failed to create CPM")
+	}
+
+	// Ensure we have a launch time that was in the past.
+	if !c.launchTime.Before(time.Now()) {
+		t.Fatalf("time travel isn't possible")
+	}
+
+	// Call the function
+	err = BdosSysCallUptime(c)
+	if err != nil {
+		t.Fatalf("unexpected error getting ticks")
+	}
+
+	// Get the before time.
+	a := c.CPU.States.HL.U16()
+
+	// Call the function
+	err = BdosSysCallUptime(c)
+	if err != nil {
+		t.Fatalf("unexpected error getting ticks")
+	}
+
+	// Get the after time.
+	b := c.CPU.States.HL.U16()
+
+	if a == b {
+		t.Fatalf("no time has passed %d %d", a, b)
+	}
 }


### PR DESCRIPTION
This pull-request implements BDOS call 0xF8 / 248, which is the F_UPTIME syscall, designed to show elapsed time since startup.

We return the time in nanoseconds rather than milliseconds, just to mix things up a little.  Though in practice the value of either measurement will wrap around so quickly the increase granularity is almost worthless.

This PR doesn't add any of the other RunCPM-specific syscalls as those have not yet been seen in the wild.  It is only the v5 of BBC BASIC which seems to call the F_UPTIME syscall for some reason.

This closes #158.