### PR TITLE
Allow the BDOS and BIOS addresses to be changed

### DIFF
--- a/cpm/cpm_test.go
+++ b/cpm/cpm_test.go
@@ -58,6 +58,11 @@ func TestSimple(t *testing.T) {
 		t.Fatalf("ccp name mismatch!")
 	}
 
+	// Ensure our BDOS and BIOS don't equal each other
+	if obj.GetBDOSAddress() == obj.GetBIOSAddress() {
+		t.Fatalf("BIOS and BDOS should be different!")
+	}
+
 	// Create a temporary file with our "RET" program in it.
 	var file *os.File
 	file, err = os.CreateTemp("", "tst-*.com")

--- a/main.go
+++ b/main.go
@@ -358,7 +358,7 @@ func main() {
 	}
 
 	// Show a startup-banner.
-	fmt.Printf("\ncpmulator %s\r\nCCP:%s input driver:%s output driver:%s\n", cpmver.GetVersionString(), obj.GetCCPName(), obj.GetInputDriver().GetName(), obj.GetOutputDriver().GetName())
+	fmt.Printf("\ncpmulator %s\r\nConsole input:%s Console output:%s BIOS:0x%04X BDOS:0x%04X CCP:%s\n", cpmver.GetVersionString(), obj.GetInputDriver().GetName(), obj.GetOutputDriver().GetName(), obj.GetBIOSAddress(), obj.GetBDOSAddress(), obj.GetCCPName())
 
 	// We will load AUTOEXEC.SUB, once, if it exists (*)
 	//


### PR DESCRIPTION
This pull request will close #175 by allowing the BDOS and BIOS addresses to be changed - via environmental variables - and updates the default values to allow a1.com to run.

The default values match those used in RunCPM which I guess means that compatability will be good..?