### PR TITLE
Emulate BIOS and BDOS calls via OUT instructions

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -51,14 +51,15 @@ This will give output like this:
 
 ## Notes on Syscalls
 
-There will be two kinds of syscalls logged:
+There will be two kinds of syscalls BIOS calls and BDOS calls.
 
-* Those that are invoked via the traditional `call 0x0005`.
-  * This will be logged as `SysCall`.
-* Those that are invoked via "`RST XX`" instructions.
-  * This will be logged as `IOSysCall`.
+We deploy a fake BIOS jump-table and a fake BDOS when the emulator launches.  By default the BIOS jump-table is located at 0xFE00 and the BDOS is located at 0xF000.
 
-In both cases the register values will be logged, individually and as pairs so you can examine them in whichever way you see fit.
+* The BIOS syscalls jump to some code that stores the syscall number in the A-register
+  * Then OUT 0xFF, A is executed.
+  * This sends configures the emulator to carry out the appropriate action.
+* The BDOS entrypoint has a tiny piece of code that just runs "OUT (C),C"
+  * This out instruction is trapped by the emulator and the syscall number can be taken from the C-register.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cpmulator - A CP/M emulator written in golang
 
-This repository contains a CP/M emulator, with integrated CCP ("Console Command Processor", i.e. shell), which is designed to run CP/M binaries.  The project was initially created to run [a text-based adventure game](https://github.com/skx/lighthouse-of-doom/), which I wrote a few years ago, to amuse my child.  (That was written in Z80 assembly language targeting CP/M, later I ported to the ZX Spectrum.)
+This repository contains a CP/M emulator, with integrated CCP ("Console Command Processor", i.e. shell), which is designed to run CP/M binaries.  The project was initially created to run [a text-based adventure game](https://github.com/skx/lighthouse-of-doom/) which I wrote a few years ago.  (That game was written in Z80 assembly language targeting CP/M, later it was ported to the ZX Spectrum.)
 
 Over time this project has become more complete, and I've now implemented enough functionity to run many of the well-known CP/M programs:
 
@@ -50,15 +50,15 @@ Releases will be made as/when features seem to justify it, but it should be note
 
 
 
-## With Docker
+## Docker-based Quick Start
 
 If you've got docker installed you can launch things by running:
 
 ```sh
-docker run -t -i ghcr.io/skx/cpmulator:master
+docker run --pull=always -t -i ghcr.io/skx/cpmulator:master
 ```
 
-**NOTE** You must run interactively with the `-t` and `-i` flags, otherwise the console setup will be broken.
+**NOTE** You must run with the `-t` and `-i` flags, otherwise the console will be broken.
 
 Once launched you can explore, for example to run Zork type:
 
@@ -67,11 +67,9 @@ Once launched you can explore, for example to run Zork type:
 * `ZORK1`
   * This will launch the Zork1 binary.
 
-Other examples are given below.
 
 
-
-## Building Locally
+## Local Quick Start
 
 * Build/Install this application.
 * Clone the associated repository of binaries:
@@ -89,7 +87,7 @@ Other examples are given below.
 
 # Usage
 
-If you launch `cpmulator` with no arguments then the default CCP ("console command processor") will be launched, dropping you into a familiar shell:
+If you launch `cpmulator` with no arguments then the default CCP will be launched, dropping you into a shell:
 
 ```sh
 $ cpmulator
@@ -231,33 +229,9 @@ Finally `A:!VERSION.COM` will show you the version of the emulator you're runnin
 
 
 
-# Sample Binaries
-
-I've placed a copy of my own [lighthouse of doom](https://github.com/skx/lighthouse-of-doom/) game within the `dist/` directory, to make it easier for you to get started:
-
-```sh
-$ cd dist/
-$ ../cpmulator LIHOUSE.COM
-..
-Written by Steve Kemp in 2021, version unreleased-git.
-
-  https://github.com/skx/lighthouse-of-doom
-
-Any references to the Paw Patrol are entirely deliberate.
-
-Press any key to start.
-```
-
-A companion repository contains a larger collection of vintage CP/M software you can use with this emulator:
-
-* [https://github.com/skx/cpm-dist](https://github.com/skx/cpm-dist)
-
-
-
-
 # Drives vs. Directories
 
-By default when you launch `cpmulator` with no arguments you'll be presented with the CCP interface, with A: as the current drive.   In this mode A:, B:, C:, and all other drives, will refer to the current-working directory where you launched the emulator from (i.e. they have the same view of files).  This is perhaps the most practical way to get started, but it means that files are repeated across drives:
+By default when you launch `cpmulator` with no arguments you'll be presented with the CCP interface, with A: as the current drive.   In this mode A:, B:, C:, and all other drives, will refer to the current-working directory from which you launched the emulator.  This is perhaps the most practical way to get started, but it means that files are repeated across drives:
 
 * i.e. "`A:FOO`" is the same as "`B:FOO`", and if you delete "`C:FOO`" you'll find it has vanished from all drives.
   * In short "`FOO`" will exist on drives `A:` all the way through to `P:`.
@@ -400,6 +374,8 @@ For reference the memory map of our CP/M looks like this:
 * Reference Documentation
   * [CP/M BDOS function reference](https://www.seasip.info/Cpm/bdos.html).
   * [CP/M BIOS function reference](https://www.seasip.info/Cpm/bios.html).
+  * [CP/M Operating System Manual](http://www.gaby.de/cpm/manuals/archive/cpm22htm/)
+    * Contains an assembler reference, DDT commands, etc, etc.
 * Other emulators which were useful resources when some functionality was unclear:
   * [https://github.com/ivanizag/iz-cpm](https://github.com/ivanizag/iz-cpm)
     * Portable CP/M emulation to run CP/M 2.2 binaries for Z80.
@@ -416,6 +392,8 @@ For reference the memory map of our CP/M looks like this:
 
 The testing that I should do before a release:
 
+* [ ] Confirm DDT can be used to trace execution of a simple binary.
+* [ ] Confirm the A1 Apple Emulator can be launched, and BASIC will run.
 * [ ] Play lighthouse of doom to completion, either victory or death.
 * [ ] Compile a program with ASM & LOAD.  Confirm it runs.
 * [ ] Compile HELLO.C and ECHO.C with Aztec C Compiler.

--- a/consolein/consolein.go
+++ b/consolein/consolein.go
@@ -86,7 +86,7 @@ type ConsoleIn struct {
 	systemPrefix string
 }
 
-// New is our constructore, it creates an input device which uses
+// New is our constructor, it creates an input device which uses
 // the specified driver.
 func New(name string) (*ConsoleIn, error) {
 

--- a/consoleout/consoleout.go
+++ b/consoleout/consoleout.go
@@ -74,7 +74,7 @@ type ConsoleOut struct {
 	driver ConsoleOutput
 }
 
-// New is our constructore, it creates an output device which uses
+// New is our constructor, it creates an output device which uses
 // the specified driver.
 func New(name string) (*ConsoleOut, error) {
 	// Downcase for consistency.

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -1063,11 +1063,7 @@ func (cpm *CPM) Out(addr uint8, val uint8) {
 		//
 		// To make sense we log this as a fatal error, and bail.
 		if val != cpm.CPU.AF.Hi {
-			slog.Error("Out() mismatch for "+callType+" handler",
-				slog.Int("Value", int(val)),
-				slog.Group("registers",
-					slog.String("AF", fmt.Sprintf("%04X", cpm.CPU.States.AF.U16())),
-				))
+			slog.Error("Out() mismatch for "+callType+" handler", slog.Int("Value", int(val)), slog.Group("registers", slog.String("AF", fmt.Sprintf("%04X", cpm.CPU.States.AF.U16()))))
 			return
 		}
 
@@ -1085,11 +1081,7 @@ func (cpm *CPM) Out(addr uint8, val uint8) {
 		//
 		// To make sense we log this as a fatal error, and bail.
 		if val != cpm.CPU.BC.Lo {
-			slog.Error("Out() mismatch for "+callType+" handler",
-				slog.Int("Value", int(val)),
-				slog.Group("registers",
-					slog.String("BC", fmt.Sprintf("%04X", cpm.CPU.States.BC.U16())),
-				))
+			slog.Error("Out() mismatch for "+callType+" handler", slog.Int("Value", int(val)), slog.Group("registers", slog.String("BC", fmt.Sprintf("%04X", cpm.CPU.States.BC.U16()))))
 			return
 		}
 

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -1025,11 +1025,18 @@ func (cpm *CPM) In(addr uint8) uint8 {
 func (cpm *CPM) Out(addr uint8, val uint8) {
 
 	if cpm.CPU.HALT {
-		fmt.Printf("Out() called when CPU is halted\r\n")
+		slog.Error("Out() called when CPU is halted",
+			slog.Group("Out",
+				slog.Int("Addr", int(addr)),
+				slog.Int("Val", int(val))))
 		return
 	}
 	if cpm.biosErr != nil {
-		fmt.Printf("Out() with pending error: %v\r\n", cpm.biosErr)
+		slog.Error("Out() called with pending error",
+			slog.Group("Out",
+				slog.Int("Addr", int(addr)),
+				slog.Int("Val", int(val)),
+				slog.String("Error", cpm.biosErr.Error())))
 		return
 	}
 

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -1189,7 +1189,8 @@ func BdosSysCallLoginVec(cpm *CPM) error {
 // BdosSysCallDriveGet returns the number of the active drive.
 func BdosSysCallDriveGet(cpm *CPM) error {
 	cpm.CPU.States.AF.Hi = cpm.currentDrive
-
+	cpm.CPU.States.HL.Lo = cpm.currentDrive
+	cpm.CPU.States.HL.Hi = 0x00
 	return nil
 }
 

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -29,6 +29,7 @@ const maxRC = 128
 
 // BdosSysCallExit implements the Exit syscall
 func BdosSysCallExit(cpm *CPM) error {
+	cpm.CPU.HALT = true
 	return ErrExit
 }
 

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -30,7 +30,7 @@ const maxRC = 128
 // BdosSysCallExit implements the Exit syscall
 func BdosSysCallExit(cpm *CPM) error {
 	cpm.CPU.HALT = true
-	return ErrExit
+	return ErrBoot
 }
 
 // BdosSysCallReadChar reads a single character from the console.

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -35,7 +35,7 @@ func BiosSysCallColdBoot(cpm *CPM) error {
 	cpm.Memory.Set(0x0004, 0)
 
 	// DMA gets reset
-	cpm.dma = DefaultDMA
+	cpm.dma = DefaultDMAAddress
 
 	return ErrBoot
 }
@@ -50,7 +50,7 @@ func BiosSysCallWarmBoot(cpm *CPM) error {
 	cpm.CPU.HL.SetU16(0)
 
 	// DMA gets reset
-	cpm.dma = DefaultDMA
+	cpm.dma = DefaultDMAAddress
 
 	return ErrBoot
 }

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -28,7 +28,7 @@ func BiosSysCallColdBoot(cpm *CPM) error {
 	cpm.CPU.HL.SetU16(0)
 
 	// Reset the stack on a cold-boot.
-	cpm.CPU.SP = 0xffff
+	cpm.CPU.SP = 0xFFFF
 
 	// Reset the drive and user-number on a cold-boot.
 	cpm.currentDrive = 0

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -29,9 +29,11 @@ func BiosSysCallColdBoot(cpm *CPM) error {
 
 	// Reset the stack on a cold-boot.
 	cpm.CPU.SP = 0xffff
-	// Reset the drive and user-number
+
+	// Reset the drive and user-number on a cold-boot.
 	cpm.currentDrive = 0
 	cpm.Memory.Set(0x0004, 0)
+
 	return ErrBoot
 }
 

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -21,11 +21,29 @@ import (
 
 // BiosSysCallColdBoot handles a cold boot.
 func BiosSysCallColdBoot(cpm *CPM) error {
+	// Reset all registers
+	cpm.CPU.AF.SetU16(0)
+	cpm.CPU.BC.SetU16(0)
+	cpm.CPU.DE.SetU16(0)
+	cpm.CPU.HL.SetU16(0)
+
+	// Reset the stack on a cold-boot.
+	cpm.CPU.SP = 0xffff
+	// Reset the drive and user-number
+	cpm.currentDrive = 0
+	cpm.Memory.Set(0x0004, 0)
 	return ErrBoot
 }
 
 // BiosSysCallWarmBoot handles a warm boot.
 func BiosSysCallWarmBoot(cpm *CPM) error {
+
+	// Reset all registers
+	cpm.CPU.AF.SetU16(0)
+	cpm.CPU.BC.SetU16(0)
+	cpm.CPU.DE.SetU16(0)
+	cpm.CPU.HL.SetU16(0)
+
 	return ErrBoot
 }
 

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -34,6 +34,9 @@ func BiosSysCallColdBoot(cpm *CPM) error {
 	cpm.currentDrive = 0
 	cpm.Memory.Set(0x0004, 0)
 
+	// DMA gets reset
+	cpm.dma = DefaultDMA
+
 	return ErrBoot
 }
 
@@ -45,6 +48,9 @@ func BiosSysCallWarmBoot(cpm *CPM) error {
 	cpm.CPU.BC.SetU16(0)
 	cpm.CPU.DE.SetU16(0)
 	cpm.CPU.HL.SetU16(0)
+
+	// DMA gets reset
+	cpm.dma = DefaultDMA
 
 	return ErrBoot
 }

--- a/cpm/cpm_bios_test.go
+++ b/cpm/cpm_bios_test.go
@@ -415,7 +415,7 @@ func TestBIOSError(t *testing.T) {
 
 	// This will fail
 	c.CPU.States.AF.Hi = 0x05
-	c.Out(0xff, 5)
+	c.Out(0xFF, 5)
 
 	// So the error should be set
 	if c.biosErr == nil {
@@ -424,6 +424,6 @@ func TestBIOSError(t *testing.T) {
 
 	// 15 == LISTST == BiosSysCallPrinterStatus
 	c.CPU.States.BC.SetU16(15)
-	c.Out(0xff, 15)
+	c.Out(0xFF, 15)
 
 }

--- a/cpm/cpm_bios_test.go
+++ b/cpm/cpm_bios_test.go
@@ -414,7 +414,8 @@ func TestBIOSError(t *testing.T) {
 	}
 
 	// This will fail
-	c.BiosHandler(5)
+	c.CPU.States.AF.Hi = 0x05
+	c.Out(0xff, 5)
 
 	// So the error should be set
 	if c.biosErr == nil {
@@ -422,6 +423,7 @@ func TestBIOSError(t *testing.T) {
 	}
 
 	// 15 == LISTST == BiosSysCallPrinterStatus
-	c.BiosHandler(15)
+	c.CPU.States.BC.SetU16(15)
+	c.Out(0xff, 15)
 
 }

--- a/cpm/cpm_bios_test.go
+++ b/cpm/cpm_bios_test.go
@@ -409,7 +409,7 @@ func TestBIOSError(t *testing.T) {
 	}
 
 	// 5 == LIST / BiosSysCallPrintChar
-	if c.biosErr != nil {
+	if c.syscallErr != nil {
 		t.Fatalf("found an error we didn't expect")
 	}
 
@@ -418,7 +418,7 @@ func TestBIOSError(t *testing.T) {
 	c.Out(0xFF, 5)
 
 	// So the error should be set
-	if c.biosErr == nil {
+	if c.syscallErr == nil {
 		t.Fatalf("found no error, but we should have done")
 	}
 

--- a/cpm/cpm_test.go
+++ b/cpm/cpm_test.go
@@ -305,6 +305,8 @@ func TestCPMCoverage(t *testing.T) {
 	// Valid: WARMBOOT
 	obj.CPU.HALT = false
 	obj.biosErr = nil
+	obj.CPU.States.AF.Hi = 0x01
+	obj.CPU.States.BC.Lo = 0x01
 	obj.Out(0xFF, 0x01)
 	if obj.biosErr != ErrBoot {
 		t.Fatalf("unexpected error")

--- a/cpm/cpm_test.go
+++ b/cpm/cpm_test.go
@@ -292,34 +292,34 @@ func TestCPMCoverage(t *testing.T) {
 
 	obj.In(0x12)
 	obj.CPU.HALT = false
-	obj.biosErr = nil
+	obj.syscallErr = nil
 	obj.Out(0x12, 0x34)
 
 	// Valid: COLDBOOT
 	obj.CPU.HALT = false
-	obj.biosErr = nil
+	obj.syscallErr = nil
 	obj.Out(0xFF, 0x00)
-	if obj.biosErr != ErrBoot {
+	if obj.syscallErr != ErrBoot {
 		t.Fatalf("unexpected error")
 	}
 	// Valid: WARMBOOT
 	obj.CPU.HALT = false
-	obj.biosErr = nil
+	obj.syscallErr = nil
 	obj.CPU.States.AF.Hi = 0x01
 	obj.CPU.States.BC.Lo = 0x01
 	obj.Out(0xFF, 0x01)
-	if obj.biosErr != ErrBoot {
+	if obj.syscallErr != ErrBoot {
 		t.Fatalf("unexpected error")
 	}
 
 	// Invalid
 	obj.CPU.HALT = false
-	obj.biosErr = nil
+	obj.syscallErr = nil
 	obj.CPU.States.AF.Hi = 0xFE
 	obj.CPU.States.BC.Lo = 0xFE
 	obj.Out(0xFE, 0xFE)
-	if obj.biosErr != ErrUnimplemented {
-		t.Fatalf("expected unimplemented, got %s", obj.biosErr)
+	if obj.syscallErr != ErrUnimplemented {
+		t.Fatalf("expected unimplemented, got %s", obj.syscallErr)
 	}
 }
 

--- a/cpm/cpm_test.go
+++ b/cpm/cpm_test.go
@@ -99,8 +99,8 @@ func TestSimple(t *testing.T) {
 
 	// Finally launch it
 	err = obj.Execute([]string{})
-	if err != nil {
-		t.Fatalf("failed to run binary!")
+	if err != ErrBoot {
+		t.Fatalf("failed to run binary %v!", err)
 	}
 
 	defer obj.IOTearDown()
@@ -287,23 +287,35 @@ func TestCPMCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create CP/M object")
 	}
+	// Ensure we have memory
+	obj.Memory = new(memory.Memory)
 
 	obj.In(0x12)
+	obj.CPU.HALT = false
+	obj.biosErr = nil
 	obj.Out(0x12, 0x34)
 
 	// Valid: COLDBOOT
+	obj.CPU.HALT = false
+	obj.biosErr = nil
 	obj.Out(0xFF, 0x00)
-	if obj.biosErr != nil {
+	if obj.biosErr != ErrBoot {
 		t.Fatalf("unexpected error")
 	}
 	// Valid: WARMBOOT
+	obj.CPU.HALT = false
+	obj.biosErr = nil
 	obj.Out(0xFF, 0x01)
-	if obj.biosErr != nil {
+	if obj.biosErr != ErrBoot {
 		t.Fatalf("unexpected error")
 	}
 
 	// Invalid
-	obj.Out(0xFF, 0xFF)
+	obj.CPU.HALT = false
+	obj.biosErr = nil
+	obj.CPU.States.AF.Hi = 0xFE
+	obj.CPU.States.BC.Lo = 0xFE
+	obj.Out(0xFE, 0xFE)
 	if obj.biosErr != ErrUnimplemented {
 		t.Fatalf("expected unimplemented, got %s", obj.biosErr)
 	}
@@ -388,8 +400,8 @@ func TestAddressOveride(t *testing.T) {
 		t.Fatalf("failed to create CPM")
 	}
 
-	if obj.bdosAddress != 0xC000 {
-		t.Fatalf("default BDOS address is wrong")
+	if obj.bdosAddress != 0xF000 {
+		t.Fatalf("default BDOS address is wrong, got %04X", obj.bdosAddress)
 	}
 
 	// Create a new CP/M helper - with env set
@@ -409,7 +421,7 @@ func TestAddressOveride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create CPM")
 	}
-	if obj.bdosAddress != 0xC000 {
+	if obj.bdosAddress != 0xF000 {
 		t.Fatalf("updated BDOS address is wrong")
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.21.5
 
 require (
 	github.com/koron-go/z80 v0.10.1
-	golang.org/x/term v0.27.0
+	golang.org/x/term v0.28.0
 )
 
 require (
 	github.com/nsf/termbox-go v1.1.1
-	golang.org/x/sys v0.28.0
+	golang.org/x/sys v0.29.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,7 @@ github.com/nsf/termbox-go v1.1.1/go.mod h1:T0cTdVuOwf7pHQNtfhnEbzHbcNyCEcVU4YPpo
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
-golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
+golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
+golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.28.0 h1:/Ts8HFuMR2E6IP/jlo7QVLZHggjKQbhu/7H0LJFr3Gg=
+golang.org/x/term v0.28.0/go.mod h1:Sw/lC2IAUZ92udQNf3WodGtn4k/XoLyZoh8v/8uiwek=

--- a/main.go
+++ b/main.go
@@ -343,12 +343,6 @@ func main() {
 				return
 			}
 
-			// Deliberate stop of execution.
-			if err == cpm.ErrExit {
-				fmt.Printf("\n")
-				return
-			}
-
 			fmt.Printf("Error running %s [%s]: %s\n",
 				program, strings.Join(args, ","), err)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,9 @@ import (
 // TestDriveChange ensures the drive-letter changes after
 // changing drives.
 func TestDriveChange(t *testing.T) {
+
+	t.Setenv("BDOS_ADDRESS", "0xb000")
+	t.Setenv("BIOS_ADDRESS", "0xbf00")
 
 	obj, err := cpm.New(cpm.WithOutputDriver("logger"))
 	if err != nil {
@@ -62,6 +66,9 @@ func TestDriveChange(t *testing.T) {
 // records - via the external API.
 func TestReadWriteRand(t *testing.T) {
 
+	t.Setenv("BDOS_ADDRESS", "0xb000")
+	t.Setenv("BIOS_ADDRESS", "0xbf00")
+
 	obj, err := cpm.New()
 	if err != nil {
 		t.Fatalf("Create CP/M failed")
@@ -79,7 +86,7 @@ func TestReadWriteRand(t *testing.T) {
 
 	// Run it
 	err = obj.Execute([]string{})
-	if err != nil && err != cpm.ErrHalt {
+	if err != nil && err != cpm.ErrBoot {
 		t.Fatalf("failed to run: %s", err)
 	}
 
@@ -95,6 +102,9 @@ func TestReadWriteRand(t *testing.T) {
 // However it is a great test to see that things work as expected.
 func TestCompleteLighthouse(t *testing.T) {
 
+	t.Setenv("BDOS_ADDRESS", "0xb000")
+	t.Setenv("BIOS_ADDRESS", "0xbf00")
+
 	obj, err := cpm.New(cpm.WithOutputDriver("logger"))
 	if err != nil {
 		t.Fatalf("Create CP/M failed")
@@ -108,11 +118,11 @@ func TestCompleteLighthouse(t *testing.T) {
 
 	obj.SetDrives(false)
 	obj.SetDrivePath("A", "dist/")
-	obj.StuffText("LIHOUSE\nAAAA\ndown\nEXAMINE DESK\nTAKE METEOR\nUP\n\nn\nQUIT\n")
+	obj.StuffText("\nLIHOUSE\nAAAA\ndown\nEXAMINE DESK\nTAKE METEOR\nUP\n\nn\nquit\n")
 
 	// Run it
 	err = obj.Execute([]string{})
-	if err != nil && err != cpm.ErrHalt {
+	if err != nil && err != cpm.ErrBoot {
 		t.Fatalf("failed to run: %s", err)
 	}
 
@@ -126,6 +136,7 @@ func TestCompleteLighthouse(t *testing.T) {
 	// Get the text written to the screen
 	out := l.GetOutput()
 
+	fmt.Printf("\n\nOUTPUT: %s\n\n", out)
 	// Ensure the game was completed - easy path.
 	if !strings.Contains(out, "Congratulations") {
 		t.Fatalf("failed to win")


### PR DESCRIPTION
This PR, if merged, would change the way that our emulator handles syscalls.  The reason for doing this would to increase our accuracy.

At the moment we fall back to the "host" to handle BDOS and BIOS syscalls when the system IP is a given value - but if other code is executing at those addresses we get confused.

This came up in the handling of DDT.COM, and A1.COM, and I guess it is a general problem.

* #112
* #175

Before this PR can be merged:

* [x] The linter must pass.
* [x] The test-cases must pass.
* [x] DDT must work "fully".
* [x] A1 must work "fully".
* [x] There must be an overhaul to how things are tested.
* [x] We must confirm no obvious regressions in the main cpm-dist binaries.

This, accidentally, closes #178 and closes #179.