### PR TITLE
fixed default BIOS/BDOS addresses

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -583,7 +583,7 @@ func New(options ...cpmoption) (*CPM, error) {
 		start:        0x0100,
 		launchTime:   time.Now(),
 		biosAddress:  envNumber("BIOS_ADDRESS", 0xFE00),
-		bdosAddress:  envNumber("BDOS_ADDRESS", 0xF000),
+		bdosAddress:  envNumber("BDOS_ADDRESS", 0xFA00),
 	}
 
 	// Allow options to override our defaults

--- a/cpm/cpm_test.go
+++ b/cpm/cpm_test.go
@@ -402,7 +402,7 @@ func TestAddressOveride(t *testing.T) {
 		t.Fatalf("failed to create CPM")
 	}
 
-	if obj.bdosAddress != 0xF000 {
+	if obj.bdosAddress != 0xFA00 {
 		t.Fatalf("default BDOS address is wrong, got %04X", obj.bdosAddress)
 	}
 
@@ -423,7 +423,7 @@ func TestAddressOveride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create CPM")
 	}
-	if obj.bdosAddress != 0xF000 {
+	if obj.bdosAddress != 0xFA00 {
 		t.Fatalf("updated BDOS address is wrong")
 	}
 


### PR DESCRIPTION
This works for both LIHOUSE.COM and A1.COM but it's a gamble for other things.  Higher choices are good, I think.

This closes #181.