### PR TITLE
193 Add carriage-returns to the newlines in messages

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -1131,7 +1131,7 @@ func (cpm *CPM) Out(addr uint8, val uint8) {
 
 		// show the function being invoked.
 		if cpm.simpleDebug {
-			fmt.Printf("%03d %s %s\n", val, callType, handler.Desc)
+			fmt.Printf("%03d %s %s\r\n", val, callType, handler.Desc)
 		}
 
 		// Log the call we're going to make

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -1367,7 +1367,7 @@ func BdosSysCallReadRand(cpm *CPM) error {
 		if err != nil {
 			slog.Error("SysCallReadRand error on virtual path",
 				slog.String("path", p),
-				slog.Error("error", err.Error()))
+				slog.String("error", err.Error()))
 		}
 
 		// Get the record to read

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -862,7 +862,9 @@ func BdosSysCallRead(cpm *CPM) error {
 		// open
 		file, err := fs.ReadFile(cpm.static, p)
 		if err != nil {
-			fmt.Printf("error on readfile for virtual path (%s):%s\n", p, err)
+			slog.Error("error on readfile for virtual path",
+				slog.String("path", p),
+				slog.String("error", err.Error()))
 		}
 		i := 0
 
@@ -1296,7 +1298,9 @@ func BdosSysCallReadRand(cpm *CPM) error {
 		// Get file size, in bytes
 		fi, err := f.Stat()
 		if err != nil {
-			fmt.Printf("ReadRand:failed to get file size of: %s", err)
+			slog.Error("ReadRand:failed to get file size",
+				slog.String("error", err.Error()))
+			return 0xFF
 		}
 		fileSize := fi.Size()
 
@@ -1308,7 +1312,9 @@ func BdosSysCallReadRand(cpm *CPM) error {
 
 		_, err = f.Seek(offset, io.SeekStart)
 		if err != nil {
-			fmt.Printf("cannot seek to position %d: %s", offset, err)
+			slog.Error("ReadRand: cannot seek to position",
+				slog.Int64("offset", offset),
+				slog.String("error", err.Error()))
 			return 0xFF
 		}
 
@@ -1319,7 +1325,9 @@ func BdosSysCallReadRand(cpm *CPM) error {
 		_, err = f.Read(data)
 		if err != nil {
 			if err != io.EOF {
-				fmt.Printf("failed to read offset %d: %s", offset, err)
+				slog.Error("ReadRand: failed to read offset",
+					slog.Int64("offset", offset),
+					slog.String("error", err.Error()))
 				return 0xFF
 			}
 		}
@@ -1357,7 +1365,9 @@ func BdosSysCallReadRand(cpm *CPM) error {
 		// open
 		file, err := fs.ReadFile(cpm.static, p)
 		if err != nil {
-			fmt.Printf("error on SysCallReadRand for virtual path (%s):%s\n", p, err)
+			slog.Error("SysCallReadRand error on virtual path",
+				slog.String("path", p),
+				slog.Error("error", err.Error()))
 		}
 
 		// Get the record to read

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -245,7 +245,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		// If it failed we're not going to terminate the syscall, or
 		// the emulator, just ignore the attempt.
 		if err != nil {
-			fmt.Printf("%s", err)
+			fmt.Printf("%s\r\n", err)
 			return nil
 		}
 
@@ -253,7 +253,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		cpm.output = driver
 
 		if old != str {
-			fmt.Printf("Input driver changed from %s to %s.\n", old, driver.GetName())
+			fmt.Printf("Input driver changed from %s to %s.\r\n", old, driver.GetName())
 		}
 
 	// Get/Set the CCP
@@ -283,7 +283,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		// See if the CCP exists
 		entry, err := ccp.Get(str)
 		if err != nil {
-			fmt.Printf("Invalid CCP name %s\n", str)
+			fmt.Printf("Invalid CCP name %s\r\n", str)
 			return nil
 		}
 
@@ -292,7 +292,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		cpm.ccp = str
 
 		if old != str {
-			fmt.Printf("CCP changed to %s [%s] Size:0x%04X Entry-Point:0x%04X\n", str, entry.Description, len(entry.Bytes), entry.Start)
+			fmt.Printf("CCP changed to %s [%s] Size:0x%04X Entry-Point:0x%04X\r\n", str, entry.Description, len(entry.Bytes), entry.Start)
 		}
 
 	// Get/Set the quiet flag
@@ -369,7 +369,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		// If it failed we're not going to terminate the syscall, or
 		// the emulator, just ignore the attempt.
 		if err != nil {
-			fmt.Printf("%s", err)
+			fmt.Printf("%s\r\n", err)
 			return nil
 		}
 
@@ -392,7 +392,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		cpm.input = driver
 
 		if oldName != str {
-			fmt.Printf("Input driver from %s to %s.\n", oldName, driver.GetName())
+			fmt.Printf("Input driver from %s to %s.\r\n", oldName, driver.GetName())
 		}
 
 	// Set the host prefix
@@ -423,7 +423,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		cpm.input.SetSystemCommandPrefix(str)
 
 	default:
-		fmt.Printf("Unknown custom BIOS function HL:%04X, ignoring", hl)
+		fmt.Printf("Ignoring unknown custom BIOS function HL:%04Xr\n", hl)
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func main() {
 	if *listCcps {
 		x := cpmccp.GetAll()
 		for _, x := range x {
-			fmt.Printf("%5s %-10s %04X bytes, entry-point %04X\n", x.Name, x.Description, len(x.Bytes), x.Start)
+			fmt.Printf("%5s %-10s %04X bytes, entry-point %04X\r\n", x.Name, x.Description, len(x.Bytes), x.Start)
 		}
 		return
 	}
@@ -116,7 +116,7 @@ func main() {
 			if name == cpm.DefaultInputDriver {
 				suffix = "\t[default]"
 			}
-			fmt.Printf("%s%s\n", name, suffix)
+			fmt.Printf("%s%s\r\n", name, suffix)
 		}
 		return
 	}
@@ -133,7 +133,7 @@ func main() {
 			if name == cpm.DefaultOutputDriver {
 				suffix = "\t[default]"
 			}
-			fmt.Printf("%s%s\n", name, suffix)
+			fmt.Printf("%s%s\r\n", name, suffix)
 		}
 		return
 	}
@@ -153,21 +153,21 @@ func main() {
 			sort.Ints(ids)
 
 			// Now show them.
-			fmt.Printf("%s syscalls:\n", name)
+			fmt.Printf("%s syscalls:\r\n", name)
 			for _, id := range ids {
 				ent := arg[uint8(id)]
 				fake := ""
 				if ent.Fake {
 					fake = "FAKE"
 				}
-				fmt.Printf("\t%03d %-20s %s\n", int(id), ent.Desc, fake)
+				fmt.Printf("\t%03d %-20s %s\r\n", int(id), ent.Desc, fake)
 			}
 		}
 
 		// Create helper - with defaults.
 		c, err := cpm.New()
 		if err != nil {
-			fmt.Printf("error creating CPM object: %s\n", err)
+			fmt.Printf("error creating CPM object: %s\r\n", err)
 			return
 		}
 
@@ -178,7 +178,7 @@ func main() {
 
 	// show version
 	if *showVersion {
-		fmt.Printf("%s\n", cpmver.GetVersionBanner())
+		fmt.Printf("%s\r\n", cpmver.GetVersionBanner())
 		return
 	}
 
@@ -207,7 +207,7 @@ func main() {
 		var err error
 		logFile, err = os.OpenFile(*logPath, os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
-			fmt.Printf("failed to open logfile for writing %s:%s\n", *logPath, err)
+			fmt.Printf("failed to open logfile for writing %s:%s\r\n", *logPath, err)
 			return
 		}
 
@@ -243,7 +243,7 @@ func main() {
 		cpm.WithContext(ctx),
 		cpm.WithCCP(*ccp))
 	if err != nil {
-		fmt.Printf("error creating CPM object: %s\n", err)
+		fmt.Printf("error creating CPM object: %s\r\n", err)
 		return
 	}
 
@@ -255,7 +255,7 @@ func main() {
 	// I/O SETUP
 	err = obj.IOSetup()
 	if err != nil {
-		fmt.Printf("Error setting up the console input driver %s:%s", *input, err)
+		fmt.Printf("Error setting up the console input driver %s:%s\r\n", *input, err)
 		return
 	}
 
@@ -264,7 +264,7 @@ func main() {
 	defer func() {
 		err := obj.IOTearDown()
 		if err != nil {
-			fmt.Printf("Error cleaning up console input driver %s:%s", *input, err)
+			fmt.Printf("Error cleaning up console input driver %s:%s\r\n", *input, err)
 		}
 	}()
 
@@ -274,7 +274,7 @@ func main() {
 	if *cd != "" {
 		err := os.Chdir(*cd)
 		if err != nil {
-			fmt.Printf("failed to change to %s:%s\n", *cd, err)
+			fmt.Printf("failed to change to %s:%s\r\n", *cd, err)
 			return
 		}
 	}
@@ -344,7 +344,7 @@ func main() {
 
 		err := obj.LoadBinary(program)
 		if err != nil {
-			fmt.Printf("Error loading program %s:%s\n", program, err)
+			fmt.Printf("Error loading program %s:%s\r\n", program, err)
 			return
 		}
 
@@ -368,16 +368,16 @@ func main() {
 				return
 			}
 
-			fmt.Printf("Error running %s [%s]: %s\n",
+			fmt.Printf("Error running %s [%s]: %s\r\n",
 				program, strings.Join(args, ","), err)
 		}
 
-		fmt.Printf("\n")
+		fmt.Printf("\r\n")
 		return
 	}
 
 	// Show a startup-banner.
-	fmt.Printf("\ncpmulator %s\r\nConsole input:%s Console output:%s BIOS:0x%04X BDOS:0x%04X CCP:%s\n", cpmver.GetVersionString(), obj.GetInputDriver().GetName(), obj.GetOutputDriver().GetName(), obj.GetBIOSAddress(), obj.GetBDOSAddress(), obj.GetCCPName())
+	fmt.Printf("\ncpmulator %s\r\nConsole input:%s Console output:%s BIOS:0x%04X BDOS:0x%04X CCP:%s\r\n", cpmver.GetVersionString(), obj.GetInputDriver().GetName(), obj.GetOutputDriver().GetName(), obj.GetBIOSAddress(), obj.GetBDOSAddress(), obj.GetCCPName())
 
 	// We will load AUTOEXEC.SUB, once, if it exists (*)
 	//
@@ -396,7 +396,7 @@ func main() {
 		// Load the CCP binary - resetting RAM in the process.
 		err := obj.LoadCCP()
 		if err != nil {
-			fmt.Printf("error loading CCP: %s\n", err)
+			fmt.Printf("error loading CCP: %s\r\n", err)
 			return
 		}
 
@@ -414,7 +414,7 @@ func main() {
 
 			// Deliberate stop of execution.
 			if err == cpm.ErrHalt {
-				fmt.Printf("\n")
+				fmt.Printf("\r\n")
 				return
 			}
 
@@ -423,7 +423,7 @@ func main() {
 				return
 			}
 
-			fmt.Printf("\nError running CCP: %s\n", err)
+			fmt.Printf("\r\nError running CCP: %s\r\n", err)
 			return
 		}
 	}


### PR DESCRIPTION
This pull-request, once complete, will close #193, by ensuring that we're consistently returning `"\r\n"` instead of `"\n"` in all our internal output methods.