### PR TITLE
Allow writing strings to the console driver

### DIFF
--- a/consoleout/consoleout.go
+++ b/consoleout/consoleout.go
@@ -97,6 +97,13 @@ func (co *ConsoleOut) GetDriver() ConsoleOutput {
 	return co.driver
 }
 
+// WriteString writes the given string, character by character, to the output driver.
+func (co *ConsoleOut) WriteString(str string) {
+	for _, c := range str {
+		co.driver.PutCharacter(uint8(c))
+	}
+}
+
 // ChangeDriver allows changing our driver at runtime.
 func (co *ConsoleOut) ChangeDriver(name string) error {
 

--- a/consoleout/consoleout_test.go
+++ b/consoleout/consoleout_test.go
@@ -77,9 +77,14 @@ func TestOutput(t *testing.T) {
 
 		d.driver.SetWriter(tmp)
 
-		for _, c := range "Steve Kemp" {
+		// Write character by character
+		for _, c := range "Steve " {
 			d.PutCharacter(byte(c))
 		}
+
+		// Now write via the helper which routes correctly to the driver
+		// and does it character by character.
+		d.WriteString("Kemp")
 
 		// Test we got the output we expected
 		if tmp.String() != "Steve Kemp" {


### PR DESCRIPTION
This pull-request closes #199 by adding a simple means to write a complete string to the currently-selected output driver.

This can be used in our internal code to easily route messages in such a way that our functional test-cases can validate them.

This closes #199.