### PR TITLE
Linter and style improvements.

### DIFF
--- a/.github/run-tests.sh
+++ b/.github/run-tests.sh
@@ -1,7 +1,44 @@
-#!/bin/sh
+#!/bin/bash
 
 # I don't even ..
 go env -w GOFLAGS="-buildvcs=false"
+
+# Install the tools we use to test our code-quality.
+#
+# Here we setup the tools to install only if the "CI" environmental variable
+# is not empty.  This is because locally I have them installed.
+#
+# NOTE: Github Actions always set CI=true
+#
+if [ -n "${CI}" ] ; then
+    go install golang.org/x/lint/golint@latest
+    go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest
+    go install honnef.co/go/tools/cmd/staticcheck@latest
+fi
+
+# Run the static-check tool - we ignore errors in goserver/static.go
+t=$(mktemp)
+staticcheck -checks all ./... > "$t"
+if [ -s "$t" ]; then
+    echo "Found errors via 'staticcheck'"
+    cat "$t"
+    rm "$t"
+    exit 1
+fi
+rm "$t"
+
+# At this point failures cause aborts
+set -e
+
+# Run the linter
+echo "Launching linter .."
+golint -set_exit_status ./...
+echo "Completed linter .."
+
+# Run the shadow-checker
+echo "Launching shadowed-variable check .."
+go vet -vettool="$(which shadow)" ./...
+echo "Completed shadowed-variable check .."
 
 # Run golang tests
 go test ./...

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,14 +1,6 @@
 on: pull_request
 name: Pull Request
 jobs:
-  golangci:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-go@v2
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/consolein/consolein.go
+++ b/consolein/consolein.go
@@ -283,7 +283,7 @@ func (co *ConsoleIn) ReadLine(max uint8) (string, error) {
 			if offset >= len(history) {
 				continue
 			}
-			offset += 1
+			offset++
 
 			eraseInput()
 
@@ -300,7 +300,7 @@ func (co *ConsoleIn) ReadLine(max uint8) (string, error) {
 			// Ctrl-C should only take effect at the start of the line.
 			// i.e. When the text is empty.
 			if text == "" {
-				ctrlCount += 1
+				ctrlCount++
 
 				// If we've hit our limit of consecutive Ctrl-Cs
 				// then we return the interrupted error-code

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -722,13 +722,10 @@ func (cpm *CPM) LoadBinary(filename string) error {
 // be changed by the user via the BIOS_ADDRESS and BDOS_ADDRESS environmental
 // variables.
 func (cpm *CPM) fixupRAM() {
-	i := 0
 
 	// The two addresses which are important
 	BIOS := int(cpm.biosAddress)
 	BDOS := int(cpm.bdosAddress)
-
-	NENTRY := 30
 
 	SETMEM := func(a int, v int) {
 		cpm.Memory.Set(uint16(a), uint8(v))
@@ -737,8 +734,6 @@ func (cpm *CPM) fixupRAM() {
 	SETMEM(0x0000, 0xC3)                /* JMP */
 	SETMEM(0x0001, ((BIOS + 3) & 0xFF)) /* Fake address of entry-point */
 	SETMEM(0x0002, ((BIOS + 3) >> 8))
-
-	SETMEM(BIOS, 0xC9) // RET
 
 	// Now we setup the initial values of the I/O byte
 	SETMEM(0x0003, 0x00)
@@ -760,7 +755,9 @@ func (cpm *CPM) fixupRAM() {
 	//
 	//     func (cpm *CPM) Out(addr uint8, val uint8)
 	//
-	for i < 30 {
+	i := 0
+	NENTRY := 30
+	for i < NENTRY {
 		/* JP <bios-entry> */
 		SETMEM(BIOS+3*i, 0xC3)
 		SETMEM(BIOS+3*i+1, (BIOS+NENTRY*3+i*5)&0xFF)

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -203,7 +203,7 @@ type CPM struct {
 	//
 	// This means we need to track state, the way we do this is to store the
 	// results here, and bump the findOffset each time find-next is called.
-	findFirstResults []fcb.FCBFind
+	findFirstResults []fcb.Find
 
 	// findOffset contains the index into findFirstResults which is
 	// to be read next.

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -61,26 +61,26 @@ var (
 	DefaultDMAAddress uint16 = 0x0080
 )
 
-// CPMHandlerType contains the signature of a function we use to
+// HandlerType contains the signature of a function we use to
 // emulate a CP/M BIOS or BDOS function.
 //
 // It is not expected that outside packages will want to add custom BIOS
 // functions, or syscalls, but this is public so that it could be done if
 // necessary.
-type CPMHandlerType func(cpm *CPM) error
+type HandlerType func(cpm *CPM) error
 
-// CPMHandler contains details of a specific call we implement.
+// Handler contains details of a specific call we implement.
 //
 // While we mostly need a "number to handler", having a name as well
 // is useful for the logs we produce, and we mark those functions that
 // don't do 100% of what they should as "Fake".
-type CPMHandler struct {
+type Handler struct {
 	// Desc contain the human-readable name of the given CP/M syscall.
 	Desc string
 
 	// Handler contains the function which should be invoked for
 	// this syscall.
-	Handler CPMHandlerType
+	Handler HandlerType
 
 	// Fake stores a quick comment on the completeness of the syscall
 	// implementation.  If Fake is set to true then the syscall is
@@ -167,11 +167,11 @@ type CPM struct {
 
 	// BDOSSyscalls contains details of the BDOS syscalls we
 	// know how to emulate, indexed by their ID.
-	BDOSSyscalls map[uint8]CPMHandler
+	BDOSSyscalls map[uint8]Handler
 
 	// BIOSSyscalls contains details of the BIOS syscalls we
 	// know how to emulate, indexed by their ID.
-	BIOSSyscalls map[uint8]CPMHandler
+	BIOSSyscalls map[uint8]Handler
 
 	// Memory contains the memory the system runs with.
 	Memory *memory.Memory
@@ -295,197 +295,197 @@ func New(options ...Option) (*CPM, error) {
 	//
 	// Create and populate our syscall table for the BDOS syscalls.
 	//
-	bdos := make(map[uint8]CPMHandler)
-	bdos[0] = CPMHandler{
+	bdos := make(map[uint8]Handler)
+	bdos[0] = Handler{
 		Desc:    "P_TERMCPM",
 		Handler: BdosSysCallExit,
 	}
-	bdos[1] = CPMHandler{
+	bdos[1] = Handler{
 		Desc:    "C_READ",
 		Handler: BdosSysCallReadChar,
 		Noisy:   true,
 	}
-	bdos[2] = CPMHandler{
+	bdos[2] = Handler{
 		Desc:    "C_WRITE",
 		Handler: BdosSysCallWriteChar,
 		Noisy:   true,
 	}
-	bdos[3] = CPMHandler{
+	bdos[3] = Handler{
 		Desc:    "A_READ",
 		Handler: BdosSysCallAuxRead,
 		Noisy:   true,
 	}
-	bdos[4] = CPMHandler{
+	bdos[4] = Handler{
 		Desc:    "A_WRITE",
 		Handler: BdosSysCallAuxWrite,
 		Noisy:   true,
 	}
-	bdos[5] = CPMHandler{
+	bdos[5] = Handler{
 		Desc:    "L_WRITE",
 		Handler: BdosSysCallPrinterWrite,
 		Fake:    true,
 		Noisy:   true,
 	}
-	bdos[6] = CPMHandler{
+	bdos[6] = Handler{
 		Desc:    "C_RAWIO",
 		Handler: BdosSysCallRawIO,
 		Noisy:   true,
 	}
-	bdos[7] = CPMHandler{
+	bdos[7] = Handler{
 		Desc:    "GET_IOBYTE",
 		Handler: BdosSysCallGetIOByte,
 	}
-	bdos[8] = CPMHandler{
+	bdos[8] = Handler{
 		Desc:    "SET_IOBYTE",
 		Handler: BdosSysCallSetIOByte,
 	}
-	bdos[9] = CPMHandler{
+	bdos[9] = Handler{
 		Desc:    "C_WRITESTRING",
 		Handler: BdosSysCallWriteString,
 	}
-	bdos[10] = CPMHandler{
+	bdos[10] = Handler{
 		Desc:    "C_READSTRING",
 		Handler: BdosSysCallReadString,
 	}
-	bdos[11] = CPMHandler{
+	bdos[11] = Handler{
 		Desc:    "C_STAT",
 		Handler: BdosSysCallConsoleStatus,
 		Noisy:   true,
 	}
-	bdos[12] = CPMHandler{
+	bdos[12] = Handler{
 		Desc:    "S_BDOSVER",
 		Handler: BdosSysCallBDOSVersion,
 	}
-	bdos[13] = CPMHandler{
+	bdos[13] = Handler{
 		Desc:    "DRV_ALLRESET",
 		Handler: BdosSysCallDriveAllReset,
 	}
-	bdos[14] = CPMHandler{
+	bdos[14] = Handler{
 		Desc:    "DRV_SET",
 		Handler: BdosSysCallDriveSet,
 	}
-	bdos[15] = CPMHandler{
+	bdos[15] = Handler{
 		Desc:    "F_OPEN",
 		Handler: BdosSysCallFileOpen,
 	}
-	bdos[16] = CPMHandler{
+	bdos[16] = Handler{
 		Desc:    "F_CLOSE",
 		Handler: BdosSysCallFileClose,
 	}
-	bdos[17] = CPMHandler{
+	bdos[17] = Handler{
 		Desc:    "F_SFIRST",
 		Handler: BdosSysCallFindFirst,
 	}
-	bdos[18] = CPMHandler{
+	bdos[18] = Handler{
 		Desc:    "F_SNEXT",
 		Handler: BdosSysCallFindNext,
 	}
-	bdos[19] = CPMHandler{
+	bdos[19] = Handler{
 		Desc:    "F_DELETE",
 		Handler: BdosSysCallDeleteFile,
 	}
-	bdos[20] = CPMHandler{
+	bdos[20] = Handler{
 		Desc:    "F_READ",
 		Handler: BdosSysCallRead,
 	}
-	bdos[21] = CPMHandler{
+	bdos[21] = Handler{
 		Desc:    "F_WRITE",
 		Handler: BdosSysCallWrite,
 	}
-	bdos[22] = CPMHandler{
+	bdos[22] = Handler{
 		Desc:    "F_MAKE",
 		Handler: BdosSysCallMakeFile,
 	}
-	bdos[23] = CPMHandler{
+	bdos[23] = Handler{
 		Desc:    "F_RENAME",
 		Handler: BdosSysCallRenameFile,
 	}
-	bdos[24] = CPMHandler{
+	bdos[24] = Handler{
 		Desc:    "DRV_LOGINVEC",
 		Handler: BdosSysCallLoginVec,
 		Fake:    true,
 	}
-	bdos[25] = CPMHandler{
+	bdos[25] = Handler{
 		Desc:    "DRV_GET",
 		Handler: BdosSysCallDriveGet,
 	}
-	bdos[26] = CPMHandler{
+	bdos[26] = Handler{
 		Desc:    "F_DMAOFF",
 		Handler: BdosSysCallSetDMA,
 	}
-	bdos[27] = CPMHandler{
+	bdos[27] = Handler{
 		Desc:    "DRV_ALLOCVEC",
 		Handler: BdosSysCallDriveAlloc,
 		Fake:    true,
 	}
-	bdos[28] = CPMHandler{
+	bdos[28] = Handler{
 		Desc:    "DRV_SETRO",
 		Handler: BdosSysCallDriveSetRO,
 		Fake:    true,
 	}
-	bdos[29] = CPMHandler{
+	bdos[29] = Handler{
 		Desc:    "DRV_ROVEC",
 		Handler: BdosSysCallDriveROVec,
 		Fake:    true,
 	}
-	bdos[30] = CPMHandler{
+	bdos[30] = Handler{
 		Desc:    "F_ATTRIB",
 		Handler: BdosSysCallSetFileAttributes,
 		Fake:    true,
 	}
-	bdos[31] = CPMHandler{
+	bdos[31] = Handler{
 		Desc:    "DRV_DPB",
 		Handler: BdosSysCallGetDriveDPB,
 		Fake:    true,
 	}
-	bdos[32] = CPMHandler{
+	bdos[32] = Handler{
 		Desc:    "F_USERNUM",
 		Handler: BdosSysCallUserNumber,
 	}
-	bdos[33] = CPMHandler{
+	bdos[33] = Handler{
 		Desc:    "F_READRAND",
 		Handler: BdosSysCallReadRand,
 	}
-	bdos[34] = CPMHandler{
+	bdos[34] = Handler{
 		Desc:    "F_WRITERAND",
 		Handler: BdosSysCallWriteRand,
 	}
-	bdos[35] = CPMHandler{
+	bdos[35] = Handler{
 		Desc:    "F_SIZE",
 		Handler: BdosSysCallFileSize,
 	}
-	bdos[36] = CPMHandler{
+	bdos[36] = Handler{
 		Desc:    "F_RANDREC",
 		Handler: BdosSysCallRandRecord,
 	}
-	bdos[37] = CPMHandler{
+	bdos[37] = Handler{
 		Desc:    "DRV_RESET",
 		Handler: BdosSysCallDriveReset,
 		Fake:    true,
 	}
-	bdos[40] = CPMHandler{
+	bdos[40] = Handler{
 		Desc:    "F_WRITEZF",
 		Handler: BdosSysCallWriteRand,
 
 		// We don't zero-pad
 		Fake: true,
 	}
-	bdos[45] = CPMHandler{
+	bdos[45] = Handler{
 		Desc:    "F_ERRMODE",
 		Handler: BdosSysCallErrorMode,
 		Fake:    true,
 	}
-	bdos[105] = CPMHandler{
+	bdos[105] = Handler{
 		Desc:    "T_GET",
 		Handler: BdosSysCallTime,
 		Fake:    true,
 	}
-	bdos[113] = CPMHandler{ // used by Turbo Pascal
+	bdos[113] = Handler{ // used by Turbo Pascal
 		Desc:    "DirectScreenFunctions",
 		Handler: BdosSysCallDirectScreenFunctions,
 		Fake:    true,
 	}
-	bdos[248] = CPMHandler{ // used by BBC BASIC v5
+	bdos[248] = Handler{ // used by BBC BASIC v5
 		Desc:    "F_UPTIME",
 		Handler: BdosSysCallUptime,
 		Fake:    true,
@@ -494,57 +494,57 @@ func New(options ...Option) (*CPM, error) {
 	//
 	// Create and populate our syscall table for the BIOS syscalls.
 	//
-	bios := make(map[uint8]CPMHandler)
-	bios[0] = CPMHandler{
+	bios := make(map[uint8]Handler)
+	bios[0] = Handler{
 		Desc:    "BOOT",
 		Handler: BiosSysCallColdBoot,
 	}
-	bios[1] = CPMHandler{
+	bios[1] = Handler{
 		Desc:    "WBOOT",
 		Handler: BiosSysCallWarmBoot,
 	}
-	bios[2] = CPMHandler{
+	bios[2] = Handler{
 		Desc:    "CONST",
 		Handler: BiosSysCallConsoleStatus,
 		Noisy:   true,
 	}
-	bios[3] = CPMHandler{
+	bios[3] = Handler{
 		Desc:    "CONIN",
 		Handler: BiosSysCallConsoleInput,
 		Noisy:   true,
 	}
-	bios[4] = CPMHandler{
+	bios[4] = Handler{
 		Desc:    "CONOUT",
 		Handler: BiosSysCallConsoleOutput,
 		Noisy:   true,
 	}
-	bios[5] = CPMHandler{
+	bios[5] = Handler{
 		Desc:    "LIST",
 		Handler: BiosSysCallPrintChar,
 		Fake:    true,
 	}
-	bios[15] = CPMHandler{
+	bios[15] = Handler{
 		Desc:    "LISTST",
 		Handler: BiosSysCallPrinterStatus,
 		Fake:    true,
 	}
-	bios[17] = CPMHandler{
+	bios[17] = Handler{
 		Desc:    "CONOST",
 		Handler: BiosSysCallScreenOutputStatus,
 		Fake:    true,
 		Noisy:   true,
 	}
-	bios[18] = CPMHandler{
+	bios[18] = Handler{
 		Desc:    "AUXIST",
 		Handler: BiosSysCallAuxInputStatus,
 		Fake:    true,
 	}
-	bios[19] = CPMHandler{
+	bios[19] = Handler{
 		Desc:    "AUXOST",
 		Handler: BiosSysCallAuxOutputStatus,
 		Fake:    true,
 	}
-	bios[31] = CPMHandler{
+	bios[31] = Handler{
 		Desc:    "RESERVE1",
 		Handler: BiosSysCallReserved1,
 		Fake:    true,
@@ -1069,7 +1069,7 @@ func (cpm *CPM) Out(addr uint8, val uint8) {
 	// We're going to lookup a handler, based on the
 	// register that makes sense.
 	//
-	var handler CPMHandler
+	var handler Handler
 
 	// Did we find it?  And if so what type was it?
 	var ok bool

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -196,18 +196,15 @@ type CPM struct {
 	// Valid values are 0-15.
 	userNumber uint8
 
-	// findFirstResults is a sneaky cache of files that match a glob.
+	// findFirstResults is used to hold a cache of files that match a glob.
 	//
 	// For finding files CP/M uses "find first" to find the first result
 	// then allows the programmer to call "find next", to continue the searching.
 	//
 	// This means we need to track state, the way we do this is to store the
-	// results here, and bump the findOffset each time find-next is called.
+	// results here, removing the head from the list each time "find next"
+	// is called.
 	findFirstResults []fcb.Find
-
-	// findOffset contains the index into findFirstResults which is
-	// to be read next.
-	findOffset int
 
 	// simpleDebug is used to just output the name of syscalls made.
 	//

--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -219,14 +219,14 @@ type CPM struct {
 	launchTime time.Time
 }
 
-// ccpoption defines a config-setting option for our constructor.
+// Option defines a config-setting option for our constructor.
 //
 // We use the decorator-pattern to allow flexible updates for the
 // configuration values we allow.
-type cpmoption func(*CPM) error
+type Option func(*CPM) error
 
 // WithCCP lets the default CCP to be changed in our constructor.
-func WithCCP(name string) cpmoption {
+func WithCCP(name string) Option {
 	return func(c *CPM) error {
 		c.ccp = name
 		return nil
@@ -234,7 +234,7 @@ func WithCCP(name string) cpmoption {
 }
 
 // WithPrinterPath allows the printer output to changed in our constructor.
-func WithPrinterPath(path string) cpmoption {
+func WithPrinterPath(path string) Option {
 	return func(c *CPM) error {
 		c.prnPath = path
 		return nil
@@ -242,7 +242,7 @@ func WithPrinterPath(path string) cpmoption {
 }
 
 // WithOutputDriver allows the default console output driver to be changed in our constructor.
-func WithOutputDriver(name string) cpmoption {
+func WithOutputDriver(name string) Option {
 
 	return func(c *CPM) error {
 
@@ -257,7 +257,7 @@ func WithOutputDriver(name string) cpmoption {
 }
 
 // WithInputDriver allows the default console input driver to be changed in our constructor.
-func WithInputDriver(name string) cpmoption {
+func WithInputDriver(name string) Option {
 
 	return func(c *CPM) error {
 
@@ -273,7 +273,7 @@ func WithInputDriver(name string) cpmoption {
 
 // WithHostExec allows executing commands on the host, by prefixing them with a
 // custom prefix in the Readline primitive.
-func WithHostExec(prefix string) cpmoption {
+func WithHostExec(prefix string) Option {
 	return func(c *CPM) error {
 		c.input.SetSystemCommandPrefix(prefix)
 		return nil
@@ -281,7 +281,7 @@ func WithHostExec(prefix string) cpmoption {
 }
 
 // WithContext allows a context to be passed to the evaluator.
-func WithContext(ctx context.Context) cpmoption {
+func WithContext(ctx context.Context) Option {
 	return func(c *CPM) error {
 		c.context = ctx
 		return nil
@@ -290,7 +290,7 @@ func WithContext(ctx context.Context) cpmoption {
 
 // New returns a new emulation object.  We support default options,
 // and new defaults may be specified via WithOutputDriver, etc, etc.
-func New(options ...cpmoption) (*CPM, error) {
+func New(options ...Option) (*CPM, error) {
 
 	//
 	// Create and populate our syscall table for the BDOS syscalls.

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -1599,7 +1599,7 @@ func BdosSysCallFileSize(cpm *CPM) error {
 
 	// Block size is used so round up, if we need to.
 	if (fileSize % blkSize) != 0 {
-		records += 1
+		records++
 	}
 
 	// Cap the size appropriately.

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -619,7 +619,6 @@ func BdosSysCallFindFirst(cpm *CPM) error {
 
 	// Previous results are now invalidated
 	cpm.findFirstResults = []fcb.Find{}
-	cpm.findOffset = 0
 
 	// Create a structure with the contents
 	fcbPtr := fcb.FromBytes(xxx)
@@ -675,7 +674,6 @@ func BdosSysCallFindFirst(cpm *CPM) error {
 	// Here we save the results in our cache,
 	// dropping the first
 	cpm.findFirstResults = res[1:]
-	cpm.findOffset = 0
 
 	// Create a new FCB and store it in the DMA entry
 	x := fcb.FromString(res[0].Name)
@@ -714,14 +712,17 @@ func BdosSysCallFindNext(cpm *CPM) error {
 	//
 	// Assume we've been called with findFirst before
 	//
-	if (len(cpm.findFirstResults) == 0) || cpm.findOffset >= len(cpm.findFirstResults) {
+	if len(cpm.findFirstResults) == 0 {
 		// Return 0xFF to signal an error
 		cpm.CPU.States.AF.Hi = 0xFF
 		return nil
 	}
 
-	res := cpm.findFirstResults[cpm.findOffset]
-	cpm.findOffset++
+	// Get the first item from the list of pending files
+	res := cpm.findFirstResults[0]
+
+	// And update our list to remove it.
+	cpm.findFirstResults = cpm.findFirstResults[1:]
 
 	// Create a new FCB and store it in the DMA entry
 	x := fcb.FromString(res.Name)

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -618,7 +618,7 @@ func BdosSysCallFindFirst(cpm *CPM) error {
 	xxx := cpm.Memory.GetRange(ptr, fcb.SIZE)
 
 	// Previous results are now invalidated
-	cpm.findFirstResults = []fcb.FCBFind{}
+	cpm.findFirstResults = []fcb.Find{}
 	cpm.findOffset = 0
 
 	// Create a structure with the contents
@@ -652,7 +652,7 @@ func BdosSysCallFindFirst(cpm *CPM) error {
 			if fcbPtr.DoesMatch(filepath.Base(path)) {
 
 				// If so append
-				res = append(res, fcb.FCBFind{
+				res = append(res, fcb.Find{
 					Host: path,
 					Name: filepath.Base(path)})
 			}

--- a/fcb/fcb.go
+++ b/fcb/fcb.go
@@ -55,14 +55,14 @@ type FCB struct {
 	R2 uint8
 }
 
-// FCBFind is the structure which is returned for files found via FindFirst / FindNext.
+// Find is the structure which is returned for files found via FindFirst / FindNext.
 //
 // This structure exists to make it easy for us to work with both the path on the host,
 // and the path within the CP/M disk.  Specifically we need to populate the size of
 // files when we return their FCB entries from either call - and that means we need
 // access to the host filesystem (i.e. cope when directories are used to represent
 // drives).
-type FCBFind struct {
+type Find struct {
 	// Host is the location on the host for the file.
 	// This might refer to the current directory, or a drive-based sub-directory.
 	Host string
@@ -337,8 +337,8 @@ func (f *FCB) DoesMatch(name string) bool {
 //
 // We try to do this by converting the entries of the named directory into FCBs
 // after ignoring those with impossible formats - i.e. not FILENAME.EXT length.
-func (f *FCB) GetMatches(prefix string) ([]FCBFind, error) {
-	var ret []FCBFind
+func (f *FCB) GetMatches(prefix string) ([]Find, error) {
+	var ret []Find
 
 	// Find files in the directory
 	files, err := os.ReadDir(prefix)
@@ -357,7 +357,7 @@ func (f *FCB) GetMatches(prefix string) ([]FCBFind, error) {
 		name := strings.ToUpper(file.Name())
 		if f.DoesMatch(name) {
 
-			var ent FCBFind
+			var ent Find
 
 			// Populate the host-path before we do anything else.
 			ent.Host = filepath.Join(prefix, file.Name())

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func main() {
 
 		// dumper is a helper to dump the contents of
 		// the given map in a human readable fashion.
-		dumper := func(name string, arg map[uint8]cpm.CPMHandler) {
+		dumper := func(name string, arg map[uint8]cpm.Handler) {
 
 			// Get the syscalls in sorted order
 			ids := []int{}


### PR DESCRIPTION
This pull-request closes #206 by updating to resolve linter warnings.

Each commit should fix something specific.

Now we're clean:

```
frodo ~/Repos/github.com/skx/cpmulator $ go-linter 
go vet -vettool=/home/skx/go/bin/bodyclose ./...
go vet -vettool=/home/skx/go/bin/sqlclosecheck ./...
go vet -vettool=/home/skx/go/bin/shadow ./...
go vet -vettool=/home/skx/go/bin/nilness ./...
gdeadcode -test ./...
oli	go vet ./...
staticcheck -checks all ./...
go-consistent ./...
govulncheck ./...
=== Symbol Results ===

No vulnerabilities found.

Your code is affected by 0 vulnerabilities.
This scan also found 0 vulnerabilities in packages you import and 4
vulnerabilities in modules you require, but your code doesn't appear to call
these vulnerabilities.
Use '-show verbose' for more details.
misspell .
frodo ~/Repos/github.com/skx/cpmulator $ golint ./...
```