### PR TITLE
Added 100% test-coverage to the prnC method

### DIFF
--- a/cpm/cpm_test.go
+++ b/cpm/cpm_test.go
@@ -173,58 +173,6 @@ func TestLoadCCP(t *testing.T) {
 
 }
 
-// TestPrinterOutput tests that printer output goes to the file as
-// expected.
-func TestPrinterOutput(t *testing.T) {
-
-	// Create a printer-output file
-	file, err := os.CreateTemp("", "tst-*.prn")
-	if err != nil {
-		t.Fatalf("failed to create temporary file")
-	}
-	defer os.Remove(file.Name())
-
-	// Create a new CP/M helper - valid
-	var obj *CPM
-	obj, err = New(WithPrinterPath(file.Name()))
-	if err != nil {
-		t.Fatalf("failed to create CPM")
-	}
-
-	if obj.prnPath != file.Name() {
-		t.Fatalf("unexpected filename for printer log")
-	}
-
-	// Now output some characters
-	err = obj.prnC('s')
-	if err != nil {
-		t.Fatalf("failed to write character to printer-file")
-	}
-
-	obj.CPU.States.DE.Lo = 'k'
-	err = BdosSysCallPrinterWrite(obj)
-	if err != nil {
-		t.Fatalf("failed to write character to printer-file")
-	}
-
-	obj.CPU.States.BC.Lo = 'x'
-	err = BiosSysCallPrintChar(obj)
-	if err != nil {
-		t.Fatalf("failed to write character to printer-file")
-	}
-
-	// Read back the file.
-	var data []byte
-	data, err = os.ReadFile(file.Name())
-	if err != nil {
-		t.Fatalf("failed to read from file")
-	}
-
-	if string(data) != "skx" {
-		t.Fatalf("printer output had the wrong content")
-	}
-}
-
 // TestLogNoisy tests that functions are updated appropriately.
 func TestLogNoisy(t *testing.T) {
 

--- a/cpm/prnc.go
+++ b/cpm/prnc.go
@@ -5,14 +5,34 @@ import (
 	"os"
 )
 
+// File is an interface that we mock so that we can fake failures to write and close
+// our printer logfile.
+type File interface {
+	// Write is designed to write data, but it does not.
+	// It will either do nothing, or return an error under testing.
+	Write([]byte) (int, error)
+
+	// Close is designed to close a file, but it does not.
+	// It will either do nothing, or return an error under testing.
+	Close() error
+}
+
+// opener is the factory that will allow creating either a real os.File, or a mockFile
+var opener func(name string, flag int, perm os.FileMode) (File, error)
+
 // prnC attempts to write the character specified to the "printer".
 //
 // We redirect printing to use a file, which defaults to "print.log", but
 // which can be changed via the CLI argument
 func (cpm *CPM) prnC(char uint8) error {
 
+	if opener == nil {
+		opener = func(name string, flag int, perm os.FileMode) (File, error) {
+			return os.OpenFile(name, flag, perm)
+		}
+	}
 	// If the file doesn't exist, create it.
-	f, err := os.OpenFile(cpm.prnPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := opener(cpm.prnPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("prnC: Failed to open file %s:%s", cpm.prnPath, err)
 	}

--- a/cpm/prnc_test.go
+++ b/cpm/prnc_test.go
@@ -1,0 +1,147 @@
+package cpm
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+// mockFile is a structure used for mocking file failures
+type mockFile struct {
+	// failWrite will trigger the Write method, from our File interface, to return an error.
+	failWrite bool
+
+	// failClose will trigger the Close method, from our File interface, to return an error.
+	failClose bool
+}
+
+// Write is the mocked Write method from the File interface, used for testing.
+func (m *mockFile) Write(p []byte) (int, error) {
+	if m.failWrite {
+		return 0, errors.New("mock write error")
+	}
+	return len(p), nil
+}
+
+// Close is the mocked Write method from the File interface, used for testing.
+func (m *mockFile) Close() error {
+	if m.failClose {
+		return errors.New("mock close error")
+	}
+	return nil
+}
+
+// TestPrinterOutput tests that printer output goes to the file as
+// expected.
+func TestPrinterOutput(t *testing.T) {
+
+	// Create a printer-output file
+	file, err := os.CreateTemp("", "tst-*.prn")
+	if err != nil {
+		t.Fatalf("failed to create temporary file")
+	}
+	defer os.Remove(file.Name())
+
+	// Create a new CP/M helper - valid
+	var obj *CPM
+	obj, err = New(WithPrinterPath(file.Name()))
+	if err != nil {
+		t.Fatalf("failed to create CPM")
+	}
+
+	if obj.prnPath != file.Name() {
+		t.Fatalf("unexpected filename for printer log")
+	}
+
+	// Now output some characters
+	err = obj.prnC('s')
+	if err != nil {
+		t.Fatalf("failed to write character to printer-file")
+	}
+
+	obj.CPU.States.DE.Lo = 'k'
+	err = BdosSysCallPrinterWrite(obj)
+	if err != nil {
+		t.Fatalf("failed to write character to printer-file")
+	}
+
+	obj.CPU.States.BC.Lo = 'x'
+	err = BiosSysCallPrintChar(obj)
+	if err != nil {
+		t.Fatalf("failed to write character to printer-file")
+	}
+
+	// Read back the file.
+	var data []byte
+	data, err = os.ReadFile(file.Name())
+	if err != nil {
+		t.Fatalf("failed to read from file")
+	}
+
+	if string(data) != "skx" {
+		t.Fatalf("printer output had the wrong content")
+	}
+}
+
+func TestWriteFail(t *testing.T) {
+
+	opener = func(name string, flag int, perm os.FileMode) (File, error) {
+		return &mockFile{failWrite: true}, nil
+	}
+
+	// Create a printer-output file
+	file, err := os.CreateTemp("", "tst-*.prn")
+	if err != nil {
+		t.Fatalf("failed to create temporary file")
+	}
+	defer os.Remove(file.Name())
+
+	// Create a new CP/M helper - valid
+	var obj *CPM
+	obj, err = New(WithPrinterPath(file.Name()))
+	if err != nil {
+		t.Fatalf("failed to create CPM")
+	}
+
+	if obj.prnPath != file.Name() {
+		t.Fatalf("unexpected filename for printer log")
+	}
+
+	// Now output a character, which we expect to fail.
+	err = obj.prnC('s')
+	if err == nil {
+		t.Fatalf("expected error, got none %s", err)
+	}
+
+}
+
+func TestWriteClose(t *testing.T) {
+
+	opener = func(name string, flag int, perm os.FileMode) (File, error) {
+		return &mockFile{failClose: true}, nil
+	}
+
+	// Create a printer-output file
+	file, err := os.CreateTemp("", "tst-*.prn")
+	if err != nil {
+		t.Fatalf("failed to create temporary file")
+	}
+	defer os.Remove(file.Name())
+
+	// Create a new CP/M helper - valid
+	var obj *CPM
+	obj, err = New(WithPrinterPath(file.Name()))
+	if err != nil {
+		t.Fatalf("failed to create CPM")
+	}
+
+	if obj.prnPath != file.Name() {
+		t.Fatalf("unexpected filename for printer log")
+	}
+
+	// Now output a character, which we expect to fail.
+	err = obj.prnC('s')
+	if err == nil {
+		t.Fatalf("expected error, got none %s", err)
+	}
+}


### PR DESCRIPTION
This method is used for our printer-logging, and now we have 100% test-coverage via a mocked os.File interface.