### PR TITLE
Allow input and output drivers to recieve options and use them

### DIFF
--- a/consolein/consolein.go
+++ b/consolein/consolein.go
@@ -81,6 +81,10 @@ type ConsoleIn struct {
 	// driver is the thing that actually reads our output.
 	driver ConsoleInput
 
+	// options store per-driver options which might be passed in the
+	// constructor.  Right now these are undocumented
+	options string
+
 	// systemPrefix is the prefix to use to trigger the execution
 	// of system commands, on the host,  in the ReadLine function
 	systemPrefix string
@@ -89,6 +93,16 @@ type ConsoleIn struct {
 // New is our constructor, it creates an input device which uses
 // the specified driver.
 func New(name string) (*ConsoleIn, error) {
+
+	// Do we have trailing options?
+	options := ""
+
+	// If we do save them
+	val := strings.Split(name, ":")
+	if len(val) == 2 {
+		name = val[0]
+		options = val[1]
+	}
 
 	// Downcase for consistency.
 	name = strings.ToLower(name)
@@ -101,7 +115,8 @@ func New(name string) (*ConsoleIn, error) {
 
 	// OK we do, return ourselves with that driver.
 	return &ConsoleIn{
-		driver: ctor(),
+		driver:  ctor(),
+		options: options,
 	}, nil
 }
 

--- a/consolein/consolein_test.go
+++ b/consolein/consolein_test.go
@@ -353,3 +353,15 @@ func TestSimpleExec(t *testing.T) {
 		t.Fatalf("failed to change directory")
 	}
 }
+
+// TestFactoryOptions ensures we have some options
+func TestFactoryOptions(t *testing.T) {
+
+	d, e := New("stty:CAKE/IS/A/LIE")
+	if e != nil {
+		t.Fatalf("failed to lookup driver by name %s", e)
+	}
+	if d.GetName() != "stty" {
+		t.Fatalf("setting options broke the name")
+	}
+}

--- a/consoleout/consoleout.go
+++ b/consoleout/consoleout.go
@@ -156,5 +156,70 @@ func (co *ConsoleOut) GetDrivers() []string {
 
 // PutCharacter outputs a character, using our selected driver.
 func (co *ConsoleOut) PutCharacter(c byte) {
+
+	// If we have no options then just output the
+	// character and have an early return.
+	if co.options == "" {
+		co.driver.PutCharacter(c)
+		return
+	}
+
+	// Options only change our newline handling at the moment.
+	// so anything that is a different character can also get
+	// printed and an early termination.
+	if c != '\r' && c != '\n' {
+		co.driver.PutCharacter(c)
+		return
+	}
+
+	// Right so we've got a CR or a LF, and we have non-empty options.
+	if c == '\r' {
+
+		// NO CR allowed?  Ignore the character
+		if strings.Contains(co.options, "CR=NONE") {
+			return
+		}
+
+		// CR should do "both"?  Do that
+		if strings.Contains(co.options, "CR=BOTH") {
+			co.driver.PutCharacter('\r')
+			co.driver.PutCharacter('\n')
+			return
+		}
+
+		// CR is just CR?  Okay
+		if strings.Contains(co.options, "CR=CR") {
+			co.driver.PutCharacter('\r')
+			return
+		}
+
+	}
+	if c == '\n' {
+
+		// No LF allowed?  Ignore the character
+		if strings.Contains(co.options, "LF=NONE") {
+			return
+		}
+
+		// LF should do "both"?   Do that.
+		if strings.Contains(co.options, "LF=BOTH") {
+			co.driver.PutCharacter('\r')
+			co.driver.PutCharacter('\n')
+			return
+		}
+
+		// LF is just LF?  Okay.
+		if strings.Contains(co.options, "LF=LF") {
+			co.driver.PutCharacter('\n')
+			return
+		}
+	}
+
+	//
+	// At this point we had CR or LF and yet none of our
+	// options made a change.
+	//
+	// Just print the character.
+	//
 	co.driver.PutCharacter(c)
 }

--- a/consoleout/consoleout.go
+++ b/consoleout/consoleout.go
@@ -72,11 +72,26 @@ type ConsoleOut struct {
 
 	// driver is the thing that actually writes our output.
 	driver ConsoleOutput
+
+	// options store per-driver options which might be passed in the
+	// constructor.  Right now these are undocumented
+	options string
 }
 
 // New is our constructor, it creates an output device which uses
 // the specified driver.
 func New(name string) (*ConsoleOut, error) {
+
+	// Do we have trailing options?
+	options := ""
+
+	// If we do save them
+	val := strings.Split(name, ":")
+	if len(val) == 2 {
+		name = val[0]
+		options = val[1]
+	}
+
 	// Downcase for consistency.
 	name = strings.ToLower(name)
 
@@ -88,7 +103,8 @@ func New(name string) (*ConsoleOut, error) {
 
 	// OK we do, return ourselves with that driver.
 	return &ConsoleOut{
-		driver: ctor(),
+		driver:  ctor(),
+		options: options,
 	}, nil
 }
 
@@ -97,10 +113,11 @@ func (co *ConsoleOut) GetDriver() ConsoleOutput {
 	return co.driver
 }
 
-// WriteString writes the given string, character by character, to the output driver.
+// WriteString writes the given string, character by character, via our
+// selected output driver.
 func (co *ConsoleOut) WriteString(str string) {
 	for _, c := range str {
-		co.driver.PutCharacter(uint8(c))
+		co.PutCharacter(uint8(c))
 	}
 }
 

--- a/consoleout/consoleout_test.go
+++ b/consoleout/consoleout_test.go
@@ -225,3 +225,25 @@ func TestADM(t *testing.T) {
 		s++
 	}
 }
+
+// TestOptionsNewline tests that the various options are tested
+func TestOptionsNewline(t *testing.T) {
+
+	known := []string{"CR=NONE", "CR=BOTH", "CR=CR", "LF=LF", "LF=BOTH", "LF=NONE", "ok"}
+
+	for _, str := range known {
+
+		x, e := New("ansi")
+		if e != nil {
+			t.Fatalf("error creating driver")
+		}
+
+		// set the options
+		x.options = str
+
+		// test a range of characters
+		x.PutCharacter('\n')
+		x.PutCharacter('\r')
+		x.PutCharacter('s')
+	}
+}

--- a/consoleout/consoleout_test.go
+++ b/consoleout/consoleout_test.go
@@ -31,6 +31,18 @@ func TestName(t *testing.T) {
 	}
 }
 
+// TestOptions ensures we have some options
+func TestOptions(t *testing.T) {
+
+	d, e := New("ansi:CAKE/IS/A/LIE")
+	if e != nil {
+		t.Fatalf("failed to lookup driver by name %s", e)
+	}
+	if d.GetName() != "ansi" {
+		t.Fatalf("setting options broke the name")
+	}
+}
+
 // TestChangeDriver ensures we can change a driver
 func TestChangeDriver(t *testing.T) {
 

--- a/cpm/cpm_bdos_test.go
+++ b/cpm/cpm_bdos_test.go
@@ -620,6 +620,11 @@ func TestFileSize(t *testing.T) {
 		if n*128 != sz {
 			t.Fatalf("size was wrong expected %d, got %d", sz, n)
 		}
+
+		err = BdosSysCallRandRecord(c)
+		if err != nil {
+			t.Fatalf("error in call %s", err.Error())
+		}
 		os.Remove(name)
 	}
 
@@ -1422,6 +1427,9 @@ func TestTicks(t *testing.T) {
 
 	// Get the before time.
 	a := c.CPU.States.HL.U16()
+
+	// This really shouldn't be necessary.
+	time.Sleep(10 * time.Millisecond)
 
 	// Call the function
 	err = BdosSysCallUptime(c)

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -178,7 +178,8 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		// Trim leading and trailing whitespace
 		str = strings.TrimSpace(str)
 
-		return str
+		// Lower-case because the CCP will upper-case CLI arguments
+		return strings.ToLower(str)
 	}
 
 	switch hl {
@@ -266,14 +267,24 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		// Do we have options?  If so show them too
 		options := ""
 		val := strings.Split(str, ":")
+		nm := str
 		if len(val) == 2 {
 			if len(val[1]) > 0 {
 				options = " with options '" + val[1] + "'"
+				nm = val[0]
 			}
 		}
 
 		cpm.output = driver
-		cpm.output.WriteString("The output driver has been changed from " + old + " to " + driver.GetName() + options + ".\r\n")
+		if nm != old {
+
+			cpm.output.WriteString("The output driver has been changed from " + old + " to " + driver.GetName() + options + ".\r\n")
+			return nil
+		}
+
+		if len(val) == 2 {
+			cpm.output.WriteString("Options changed to " + val[1] + " for " + driver.GetName() + ".\r\n")
+		}
 		return nil
 
 	// Get/Set the CCP
@@ -430,14 +441,23 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		// Do we have options?  If so show them too
 		options := ""
 		val := strings.Split(str, ":")
+		nm := str
 		if len(val) == 2 {
 			if len(val[1]) > 0 {
 				options = " with options '" + val[1] + "'"
+				nm = val[0]
 			}
 		}
 
 		cpm.input = driver
-		cpm.output.WriteString("Input driver changed from " + oldName + " to " + driver.GetName() + options + ".\r\n")
+		if nm != oldName {
+			cpm.output.WriteString("Input driver changed from " + oldName + " to " + driver.GetName() + options + ".\r\n")
+			return nil
+		}
+
+		if len(val) == 2 {
+			cpm.output.WriteString("Options changed to " + val[1] + " for " + driver.GetName() + ".\r\n")
+		}
 		return nil
 
 	// Set the host prefix

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -169,15 +169,16 @@ func BiosSysCallReserved1(cpm *CPM) error {
 	getStringFromMemory := func(addr uint16) string {
 		str := ""
 		x := cpm.Memory.Get(addr)
-		for x != ' ' && x != 0x00 {
+		for x != 0x00 {
 			str += string(x)
 			addr++
 			x = cpm.Memory.Get(addr)
 		}
 
-		// Useful when the CCP has passed a string, because
-		// that uppercases all input
-		return strings.ToLower(str)
+		// Trim leading and trailing whitespace
+		str = strings.TrimSpace(str)
+
+		return str
 	}
 
 	switch hl {
@@ -238,6 +239,11 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		// value.  Get the value
 		str := getStringFromMemory(de)
 
+		if str == "" {
+			cpm.output.WriteString("Ignoring empty parameter.\r\n")
+			return nil
+		}
+
 		// Get the old value
 		old := cpm.output.GetName()
 
@@ -257,8 +263,17 @@ func BiosSysCallReserved1(cpm *CPM) error {
 			return nil
 		}
 
+		// Do we have options?  If so show them too
+		options := ""
+		val := strings.Split(str, ":")
+		if len(val) == 2 {
+			if len(val[1]) > 0 {
+				options = " with options '" + val[1] + "'"
+			}
+		}
+
 		cpm.output = driver
-		cpm.output.WriteString("The output driver has been changed from " + old + " to " + str + ".\r\n")
+		cpm.output.WriteString("The output driver has been changed from " + old + " to " + driver.GetName() + options + ".\r\n")
 		return nil
 
 	// Get/Set the CCP
@@ -281,6 +296,11 @@ func BiosSysCallReserved1(cpm *CPM) error {
 
 		// Get the string pointed to by DE
 		str := getStringFromMemory(de)
+
+		if str == "" {
+			cpm.output.WriteString("Ignoring empty parameter.\r\n")
+			return nil
+		}
 
 		// If there is no change do nothing
 		if str == cpm.ccp {
@@ -370,6 +390,11 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		// value.  Get the value.
 		str := getStringFromMemory(de)
 
+		if str == "" {
+			cpm.output.WriteString("Ignoring empty parameter.\r\n")
+			return nil
+		}
+
 		// Get the old value
 		oldName := cpm.input.GetName()
 
@@ -384,31 +409,35 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		//
 		// This might mean we have console output going to a weird place if
 		// we have failures..
-		err := cpm.input.TearDown()
-		if err != nil {
-			cpm.output.WriteString("Error cleaning up the old input-driver, " + err.Error() + ".\r\n")
-			return nil
-		}
+		_ = cpm.input.TearDown()
 
 		// Create the new driver
-		driver, err2 := consolein.New(str)
-		if err2 != nil {
-			cpm.output.WriteString("Error creating the new driver, " + err2.Error() + ".\r\n")
-			return err2
+		driver, err := consolein.New(str)
+		if err != nil {
+			cpm.output.WriteString("Error creating the new driver, " + err.Error() + ".\r\n")
+			return err
 		}
 
 		// We need to setup the new driver.
 		//
 		// If this fails we also abort the change-attempt.
-		err2 = driver.Setup()
-		if err2 != nil {
-			cpm.output.WriteString("Error setting up the new driver, " + err2.Error() + ".\r\n")
-			return err2
+		err = driver.Setup()
+		if err != nil {
+			cpm.output.WriteString("Error setting up the new driver, " + err.Error() + ".\r\n")
+			return err
+		}
+
+		// Do we have options?  If so show them too
+		options := ""
+		val := strings.Split(str, ":")
+		if len(val) == 2 {
+			if len(val[1]) > 0 {
+				options = " with options '" + val[1] + "'"
+			}
 		}
 
 		cpm.input = driver
-
-		cpm.output.WriteString("Input driver changed from " + oldName + " to " + str + ".\r\n")
+		cpm.output.WriteString("Input driver changed from " + oldName + " to " + driver.GetName() + options + ".\r\n")
 		return nil
 
 	// Set the host prefix
@@ -437,7 +466,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 			cpm.input.SetSystemCommandPrefix(str)
 		}
 
-	// Disable extentions / filesystem
+	// Disable extensions / filesystem
 	case 0x0009:
 
 		switch de {

--- a/cpm/cpm_bios_test.go
+++ b/cpm/cpm_bios_test.go
@@ -68,6 +68,9 @@ func TestStatus(t *testing.T) {
 		t.Fatalf("aux output status was wrong")
 	}
 
+	if BiosSysCallReserved1NOP(c) != nil {
+		t.Fatalf("unexpected error")
+	}
 }
 
 func TestCustom(t *testing.T) {
@@ -158,7 +161,7 @@ func TestCustom(t *testing.T) {
 	// set to "null"
 	c.CPU.States.HL.SetU16(0x0002)
 	c.CPU.States.DE.SetU16(0xFE00)
-	c.Memory.SetRange(0xFE00, []byte{'n', 'u', 'l', 'l', ' '}...)
+	c.Memory.SetRange(0xFE00, []byte{'n', 'u', 'l', 'l', 0x00}...)
 	err = BiosSysCallReserved1(c)
 	if err != nil {
 		t.Fatalf("error calling reserved function")
@@ -167,7 +170,34 @@ func TestCustom(t *testing.T) {
 	// set to "null" - a second time
 	c.CPU.States.HL.SetU16(0x0002)
 	c.CPU.States.DE.SetU16(0xFE00)
-	c.Memory.SetRange(0xFE00, []byte{'n', 'u', 'l', 'l', ' '}...)
+	c.Memory.SetRange(0xFE00, []byte{'n', 'u', 'l', 'l', 0x00}...)
+	err = BiosSysCallReserved1(c)
+	if err != nil {
+		t.Fatalf("error calling reserved function")
+	}
+
+	// set to "null" - again with empty options
+	c.CPU.States.HL.SetU16(0x0002)
+	c.CPU.States.DE.SetU16(0xFE00)
+	c.Memory.SetRange(0xFE00, []byte{'n', 'u', 'l', 'l', ':', 0x00}...)
+	err = BiosSysCallReserved1(c)
+	if err != nil {
+		t.Fatalf("error calling reserved function")
+	}
+
+	// set to ""
+	c.CPU.States.HL.SetU16(0x0002)
+	c.CPU.States.DE.SetU16(0xFE00)
+	c.Memory.SetRange(0xFE00, []byte{0x00}...)
+	err = BiosSysCallReserved1(c)
+	if err != nil {
+		t.Fatalf("error calling reserved function")
+	}
+
+	// set to "null" - again with options
+	c.CPU.States.HL.SetU16(0x0002)
+	c.CPU.States.DE.SetU16(0xFE00)
+	c.Memory.SetRange(0xFE00, []byte{'n', 'u', 'l', 'l', ':', 'f', 'o', 0x00}...)
 	err = BiosSysCallReserved1(c)
 	if err != nil {
 		t.Fatalf("error calling reserved function")
@@ -219,7 +249,34 @@ func TestCustom(t *testing.T) {
 	// set to "ccpz", again
 	c.CPU.States.HL.SetU16(0x0003)
 	c.CPU.States.DE.SetU16(0xFE00)
-	c.Memory.SetRange(0xFE00, []byte{'c', 'c', 'p', 'z', ' '}...)
+	c.Memory.SetRange(0xFE00, []byte{'c', 'c', 'p', 'z', 0x00}...)
+	err = BiosSysCallReserved1(c)
+	if err != nil {
+		t.Fatalf("error calling reserved function")
+	}
+
+	// set to "ccpz", again
+	c.CPU.States.HL.SetU16(0x0003)
+	c.CPU.States.DE.SetU16(0xFE00)
+	c.Memory.SetRange(0xFE00, []byte{'c', 'c', 'p', 'z', 0x00}...)
+	err = BiosSysCallReserved1(c)
+	if err != nil {
+		t.Fatalf("error calling reserved function")
+	}
+
+	// set to "ccpz", again
+	c.CPU.States.HL.SetU16(0x0003)
+	c.CPU.States.DE.SetU16(0xFE00)
+	c.Memory.SetRange(0xFE00, []byte{'C', 'C', 'P', 'Z', 0x00}...)
+	err = BiosSysCallReserved1(c)
+	if err != nil {
+		t.Fatalf("error calling reserved function")
+	}
+
+	// set to an empty string
+	c.CPU.States.HL.SetU16(0x0003)
+	c.CPU.States.DE.SetU16(0xFE00)
+	c.Memory.SetRange(0xFE00, []byte{0x00}...)
 	err = BiosSysCallReserved1(c)
 	if err != nil {
 		t.Fatalf("error calling reserved function")
@@ -315,19 +372,55 @@ func TestCustom(t *testing.T) {
 		t.Fatalf("wrong console driver '%s'", str)
 	}
 
+	// set to "file" this will fail as the file doesn't exist
+	c.CPU.States.HL.SetU16(0x0007)
+	c.CPU.States.DE.SetU16(0xFE00)
+	c.Memory.SetRange(0xFE00, []byte{'f', 'i', 'l', 'e', 0x00}...)
+	err = BiosSysCallReserved1(c)
+	if err == nil {
+		t.Fatalf("expected error, got none.")
+	}
+
 	// set to "stty"
 	c.CPU.States.HL.SetU16(0x0007)
 	c.CPU.States.DE.SetU16(0xFE00)
-	c.Memory.SetRange(0xFE00, []byte{'s', 't', 't', 'y', ' '}...)
+	c.Memory.SetRange(0xFE00, []byte{'s', 't', 't', 'y', 0x00}...)
 	err = BiosSysCallReserved1(c)
 	if err != nil {
-		t.Fatalf("error calling reserved function")
+		t.Fatalf("error calling reserved function %s", err)
 	}
 
 	// set to "stty", again
 	c.CPU.States.HL.SetU16(0x0007)
 	c.CPU.States.DE.SetU16(0xFE00)
-	c.Memory.SetRange(0xFE00, []byte{'s', 't', 't', 'y', ' '}...)
+	c.Memory.SetRange(0xFE00, []byte{'s', 't', 't', 'y', 0x00}...)
+	err = BiosSysCallReserved1(c)
+	if err != nil {
+		t.Fatalf("error calling reserved function %s", err)
+	}
+
+	// set to an empty string
+	c.CPU.States.HL.SetU16(0x0007)
+	c.CPU.States.DE.SetU16(0xFE00)
+	c.Memory.SetRange(0xFE00, []byte{0x00}...)
+	err = BiosSysCallReserved1(c)
+	if err != nil {
+		t.Fatalf("error calling reserved function %s", err)
+	}
+
+	// set to "stty", again this time with options too
+	c.CPU.States.HL.SetU16(0x0007)
+	c.CPU.States.DE.SetU16(0xFE00)
+	c.Memory.SetRange(0xFE00, []byte{'s', 't', 't', 'y', ':', 'f', 'o', 0x00}...)
+	err = BiosSysCallReserved1(c)
+	if err != nil {
+		t.Fatalf("error calling reserved function")
+	}
+
+	// set to "stty", again this time with empty options
+	c.CPU.States.HL.SetU16(0x0007)
+	c.CPU.States.DE.SetU16(0xFE00)
+	c.Memory.SetRange(0xFE00, []byte{'s', 't', 't', 'y', ':', 0x00}...)
 	err = BiosSysCallReserved1(c)
 	if err != nil {
 		t.Fatalf("error calling reserved function")
@@ -336,7 +429,7 @@ func TestCustom(t *testing.T) {
 	// set to "steve" - this will fail
 	c.CPU.States.HL.SetU16(0x0007)
 	c.CPU.States.DE.SetU16(0xFE00)
-	c.Memory.SetRange(0xFE00, []byte{'s', 't', 'e', 'v', 'e', ' '}...)
+	c.Memory.SetRange(0xFE00, []byte{'s', 't', 'e', 'v', 'e', 0x00}...)
 	err = BiosSysCallReserved1(c)
 	if err == nil {
 		t.Fatalf("error calling reserved function")
@@ -371,7 +464,7 @@ func TestCustom(t *testing.T) {
 	// set to "!!"
 	c.CPU.States.HL.SetU16(0x0008)
 	c.CPU.States.DE.SetU16(0xFE00)
-	c.Memory.SetRange(0xFE00, []byte{'!', '!', ' '}...)
+	c.Memory.SetRange(0xFE00, []byte{'!', '!', ' ', 0x00}...)
 	err = BiosSysCallReserved1(c)
 	if err != nil {
 		t.Fatalf("error calling reserved function")
@@ -389,7 +482,7 @@ func TestCustom(t *testing.T) {
 		t.Fatalf("unexpected systemcommandprefix '%s'", str)
 	}
 	if c.input.GetSystemCommandPrefix() != "!!" {
-		t.Fatalf("unexpected mismatch in systemcommandprefix")
+		t.Fatalf("unexpected mismatch in systemcommandprefix, got '%v'", c.input.GetSystemCommandPrefix())
 	}
 
 	// set to "/clear"

--- a/test/ccp2.pat
+++ b/test/ccp2.pat
@@ -1,7 +1,7 @@
 The Ctrl-C count is currently set to
 The prefix for executing commands on the host is unset.
 Running commands on the host is disabled.
-CCP is already set to CCP, doing nothing.
-CCP changed to CCPZ
-CCP is already set to CCPZ, doing nothing.
-Error changing CCP to MONDAY, CCP MONDAY not found - valid choices are: ccp,ccpz
+CCP is already set to ccp, doing nothing.
+CCP changed to ccpz
+CCP is already set to ccpz, doing nothing.
+Error changing CCP to monday, CCP monday not found - valid choices are: ccp,ccpz

--- a/test/ccp2.pat
+++ b/test/ccp2.pat
@@ -1,7 +1,7 @@
 The Ctrl-C count is currently set to
 The prefix for executing commands on the host is unset.
 Running commands on the host is disabled.
-CCP is already set to ccp, doing nothing.
-CCP changed to ccpz
-CCP is already set to ccpz, doing nothing.
-Error changing CCP to monday, CCP monday not found - valid choices are: ccp,ccpz
+CCP is already set to CCP, doing nothing.
+CCP changed to CCPZ
+CCP is already set to CCPZ, doing nothing.
+Error changing CCP to MONDAY, CCP MONDAY not found - valid choices are: ccp,ccpz


### PR DESCRIPTION
This pull request, once complete, will close #212 by allowing arbitrary custom options to be passed to our input and output drivers.

The options will be used to (globally) change newline handling, in a flexible way.
