### PR TITLE
Output shell-commands via our output layer

### DIFF
--- a/consolein/consolein.go
+++ b/consolein/consolein.go
@@ -17,6 +17,11 @@ import (
 // ErrInterrupted is returned if the user presses Ctrl-C when in our ReadLine function.
 var ErrInterrupted error = fmt.Errorf("INTERRUPTED")
 
+// ErrShowOutput is a special sentinel value that is used to signal that the ReadLine
+// function needs to write some output to the console.  As that would be a layering
+// violation it is handled indirectly.
+var ErrShowOutput error = fmt.Errorf("SHOW_OUTPUT")
+
 // ConsoleInput is the interface that must be implemented by anything
 // that wishes to be used as an input driver.
 //
@@ -392,31 +397,21 @@ func (co *ConsoleIn) ReadLine(max uint8) (string, error) {
 
 		// cd is a special command.
 		if strings.HasPrefix(text, "cd ") {
-			bits := strings.Split(text, " ")
-			if len(bits) >= 2 {
-				dir := bits[1]
-				err := os.Chdir(dir)
-				if err != nil {
-					fmt.Printf("\r\nError changing to directory %s: %s\r\n", dir, err)
-				}
+
+			// strip off the "cd " prefix
+			dir := strings.TrimSpace(text[3:])
+
+			// try to change directory
+			err := os.Chdir(dir)
+			if err != nil {
+				return fmt.Sprintf("\r\nError changing to directory '%s': %s\r\n", dir, err), ErrShowOutput
 			}
+			// No error, just recurse
 			return co.ReadLine(max)
 		}
 
-		// Split the command, naively.
-		var bits []string
-		bits = strings.Split(text, " ")
-
-		// Of course we might be using the shell.
-		useShell := false
-		if strings.Contains(text, ">") || strings.Contains(text, "&") || strings.Contains(text, "|") || strings.Contains(text, "<") {
-			useShell = true
-		}
-
-		// If we are we wrap the command.
-		if useShell {
-			bits = []string{"bash", "-c", text}
-		}
+		// Wrap the command so it is executed via a shell
+		bits := []string{"bash", "-c", text}
 
 		// Prepare to run the command, capturing STDOUT & STDERR
 		cmd := exec.Command(bits[0], bits[1:]...)
@@ -428,16 +423,20 @@ func (co *ConsoleIn) ReadLine(max uint8) (string, error) {
 		// Actually run the command
 		err := cmd.Run()
 		if err != nil {
-			fmt.Printf("\r\nerror running command '%s' %s%s\r\n", text, err.Error(), execErr.Bytes())
-		} else {
-			out := execOut.String()
-			out += execErr.String()
-			out = strings.ReplaceAll(out, "\n", "\n\r")
-			fmt.Printf("\r\n%s\r\n", out)
+			return fmt.Sprintf("\r\nerror running command '%s' %s%s\r\n", text, err.Error(), execErr.Bytes()), ErrShowOutput
 		}
 
-		// Read the input again, since we "stole" it via the exec handling.
-		return co.ReadLine(max)
+		// No error.
+		out := execOut.String()
+		out += execErr.String()
+		out = strings.ReplaceAll(out, "\n", "\n\r")
+
+		if len(out) > 0 {
+			return fmt.Sprintf("\r\n%s\r\n", out), ErrShowOutput
+		}
+
+		// No output, show a newline
+		return "\r\n", ErrShowOutput
 	}
 
 	// Return the text

--- a/consolein/consolein.go
+++ b/consolein/consolein.go
@@ -153,7 +153,7 @@ func (co *ConsoleIn) GetDrivers() []string {
 	valid := []string{}
 
 	for x := range handlers.m {
-		if x != "file" {
+		if x != "file" && x != "error" {
 			valid = append(valid, x)
 		}
 	}

--- a/consolein/consolein_test.go
+++ b/consolein/consolein_test.go
@@ -356,7 +356,7 @@ func TestSimpleExec(t *testing.T) {
 	// Setup input to run a CD that will fail
 	ch.SetSystemCommandPrefix("!!")
 	ch.StuffInput("!!cd /this(path)/is/missing\ninput\n")
-	out, err = ch.ReadLine(199)
+	_, err = ch.ReadLine(199)
 	if err != ErrShowOutput {
 		t.Fatalf("got error, but not the one we expected: %s", err)
 	}

--- a/consolein/consolein_test.go
+++ b/consolein/consolein_test.go
@@ -196,7 +196,7 @@ func TestPending(t *testing.T) {
 // TestDriverRegistration performs some sanity-check on our driver-registration.
 func TestDriverRegistration(t *testing.T) {
 
-	expectedCount := 3
+	expectedCount := 4
 	found := len(handlers.m)
 	if found != expectedCount {
 		t.Fatalf("wrong number of handlers.  found %d, expected %d", found, expectedCount)
@@ -290,7 +290,7 @@ func TestDriverRegistration(t *testing.T) {
 	// drivers in this call, because we hide the "file"-driver.
 	//
 	found = len(obj.GetDrivers())
-	if found != expectedCount-1 {
+	if found != expectedCount-2 {
 		t.Fatalf("wrong number of handlers.  found %d, expected %d", found, expectedCount)
 	}
 }

--- a/consolein/drv_error.go
+++ b/consolein/drv_error.go
@@ -1,0 +1,55 @@
+// drv_error is a console input-driver which only returns errors.
+//
+// This driver is only used for testing purposes.
+
+package consolein
+
+import (
+	"fmt"
+)
+
+var (
+	// ErrorInputName contains the name of this driver.
+	ErrorInputName = "error"
+)
+
+// ErrorInput is an input-driver that only returns errors, and
+// is used for testing.
+type ErrorInput struct {
+}
+
+// Setup is a NOP.
+func (ei *ErrorInput) Setup() error {
+	return nil
+}
+
+// TearDown is a NOP.
+func (ei *ErrorInput) TearDown() error {
+	return nil
+}
+
+// PendingInput always pretends input is pending.
+//
+// However when input is polled for, via BlockForCharacterNoEcho,
+// an error will always be returned.
+func (ei *ErrorInput) PendingInput() bool {
+	return true
+}
+
+// GetName returns the name of this driver, "error".
+func (ei *ErrorInput) GetName() string {
+	return ErrorInputName
+}
+
+// BlockForCharacterNoEcho always returns an error when
+// invoked to read pending input.
+func (ei *ErrorInput) BlockForCharacterNoEcho() (byte, error) {
+	return 0x00, fmt.Errorf("DRV_ERROR")
+}
+
+// init registers our driver, by name.
+func init() {
+	Register(ErrorInputName, func() ConsoleInput {
+		return new(ErrorInput)
+	})
+}

--- a/consolein/drv_file.go
+++ b/consolein/drv_file.go
@@ -12,6 +12,11 @@ import (
 	"time"
 )
 
+var (
+	// FileInputName contains the name of this driver
+	FileInputName = "file"
+)
+
 // FileInput is an input-driver that returns fake console input
 // by reading and returning the contents of a file ("input.txt"
 // by default, but this may be changed).
@@ -251,12 +256,12 @@ func (fi *FileInput) BlockForCharacterNoEcho() (byte, error) {
 
 // GetName is part of the module API, and returns the name of this driver.
 func (fi *FileInput) GetName() string {
-	return "file"
+	return FileInputName
 }
 
 // init registers our driver, by name.
 func init() {
-	Register("file", func() ConsoleInput {
+	Register(FileInputName, func() ConsoleInput {
 		return new(FileInput)
 	})
 }

--- a/consolein/drv_file_test.go
+++ b/consolein/drv_file_test.go
@@ -4,12 +4,13 @@ import (
 	"io"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestFileSetup(t *testing.T) {
 
 	// Create a temporary file
-	file, err := os.CreateTemp("", "in.txt")
+	file, err := os.CreateTemp("", "in0.txt")
 	if err != nil {
 		t.Fatalf("failed to create temporary file")
 	}
@@ -39,6 +40,8 @@ func TestFileSetup(t *testing.T) {
 
 	c := 0
 	str := ""
+
+	x.delayUntil = time.Now().Add(1 * time.Second)
 
 	for c < 3 {
 		var out byte
@@ -195,7 +198,7 @@ func TestOptions(t *testing.T) {
 func TestNewlineN(t *testing.T) {
 
 	// Create a temporary file
-	file, err := os.CreateTemp("", "in.txt")
+	file, err := os.CreateTemp("", "in2.txt")
 	if err != nil {
 		t.Fatalf("failed to create temporary file")
 	}
@@ -246,7 +249,7 @@ func TestNewlineN(t *testing.T) {
 func TestNewlineM(t *testing.T) {
 
 	// Create a temporary file
-	file, err := os.CreateTemp("", "in.txt")
+	file, err := os.CreateTemp("", "in3.txt")
 	if err != nil {
 		t.Fatalf("failed to create temporary file")
 	}
@@ -296,7 +299,7 @@ func TestNewlineM(t *testing.T) {
 func TestNewlineBoth(t *testing.T) {
 
 	// Create a temporary file
-	file, err := os.CreateTemp("", "in.txt")
+	file, err := os.CreateTemp("", "in1.txt")
 	if err != nil {
 		t.Fatalf("failed to create temporary file")
 	}
@@ -346,7 +349,7 @@ func TestNewlineBoth(t *testing.T) {
 func TestNewlineBogus(t *testing.T) {
 
 	// Create a temporary file
-	file, err := os.CreateTemp("", "in.txt")
+	file, err := os.CreateTemp("", "in4.txt")
 	if err != nil {
 		t.Fatalf("failed to create temporary file")
 	}
@@ -380,7 +383,7 @@ func TestNewlineBogus(t *testing.T) {
 func TestNewlineMissing(t *testing.T) {
 
 	// Create a temporary file
-	file, err := os.CreateTemp("", "in.txt")
+	file, err := os.CreateTemp("", "in5.txt")
 	if err != nil {
 		t.Fatalf("failed to create temporary file")
 	}
@@ -423,5 +426,39 @@ func TestNewlineMissing(t *testing.T) {
 	}
 	if str != "hi\n" {
 		t.Fatalf("error in string, got '%v' '%s'", str, str)
+	}
+}
+
+func TestTimer(t *testing.T) {
+
+	// Create a temporary file
+	file, err := os.CreateTemp("", "in5.txt")
+	if err != nil {
+		t.Fatalf("failed to create temporary file")
+	}
+	defer os.Remove(file.Name())
+
+	_, err = file.Write([]byte("nothing: bogus\n--\nhi\n"))
+	if err != nil {
+		t.Fatalf("failed to write to temporary file")
+	}
+
+	t.Setenv("INPUT_FILE", file.Name())
+
+	// Create a helper
+	x := FileInput{}
+
+	ch := ConsoleIn{}
+	ch.driver = &x
+
+	sErr := ch.Setup()
+	if sErr != nil {
+		t.Fatalf("failed to setup driver %s", sErr.Error())
+	}
+
+	x.delayUntil = time.Now().Add(48 * time.Hour)
+
+	if x.PendingInput() {
+		t.Fatalf("expected no input")
 	}
 }

--- a/consolein/drv_stty.go
+++ b/consolein/drv_stty.go
@@ -16,6 +16,11 @@ import (
 	"golang.org/x/term"
 )
 
+var (
+	// STTYInputName contains the name of this driver.
+	STTYInputName = "stty"
+)
+
 // EchoStatus is used to record our current state.
 type EchoStatus int
 
@@ -149,12 +154,12 @@ func (si *STTYInput) enableEcho() {
 
 // GetName is part of the module API, and returns the name of this driver.
 func (si *STTYInput) GetName() string {
-	return "stty"
+	return STTYInputName
 }
 
 // init registers our driver, by name.
 func init() {
-	Register("stty", func() ConsoleInput {
+	Register(STTYInputName, func() ConsoleInput {
 		return new(STTYInput)
 	})
 }

--- a/consolein/drv_term.go
+++ b/consolein/drv_term.go
@@ -18,6 +18,11 @@ import (
 	"golang.org/x/term"
 )
 
+var (
+	// TermboxInputName contains the name of this driver
+	TermboxInputName = "term"
+)
+
 // TermboxInput is our input-driver, using termbox
 type TermboxInput struct {
 
@@ -134,12 +139,12 @@ func (ti *TermboxInput) BlockForCharacterNoEcho() (byte, error) {
 
 // GetName is part of the module API, and returns the name of this driver.
 func (ti *TermboxInput) GetName() string {
-	return "term"
+	return TermboxInputName
 }
 
 // init registers our driver, by name.
 func init() {
-	Register("term", func() ConsoleInput {
+	Register(TermboxInputName, func() ConsoleInput {
 		return new(TermboxInput)
 	})
 }

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -242,6 +242,17 @@ func BdosSysCallReadString(cpm *CPM) error {
 			// Reboot the system
 			return ErrBoot
 		}
+		// We used the command-execution method
+		// and this resulted in output to send to
+		// the console/user.
+		if err == consolein.ErrShowOutput {
+
+			cpm.output.WriteString(text)
+
+			// Now we're going to re-run.
+			return BdosSysCallReadString(cpm)
+		}
+
 		return err
 	}
 

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -242,6 +242,7 @@ func BdosSysCallReadString(cpm *CPM) error {
 			// Reboot the system
 			return ErrBoot
 		}
+
 		// We used the command-execution method
 		// and this resulted in output to send to
 		// the console/user.
@@ -456,9 +457,8 @@ func BdosSysCallFileOpen(cpm *CPM) error {
 		fLen := uint8(len(virt) / blkSize)
 
 		// Set record-count
-		if fLen > maxRC {
-			fcbPtr.RC = maxRC
-		} else {
+		fcbPtr.RC = maxRC
+		if fLen < maxRC {
 			fcbPtr.RC = fLen
 		}
 
@@ -513,9 +513,8 @@ func BdosSysCallFileOpen(cpm *CPM) error {
 	fLen := uint8(fileSize / blkSize)
 
 	// Set record-count
-	if fLen > maxRC {
-		fcbPtr.RC = maxRC
-	} else {
+	fcbPtr.RC = maxRC
+	if fLen < maxRC {
 		fcbPtr.RC = fLen
 	}
 
@@ -1090,9 +1089,8 @@ func BdosSysCallMakeFile(cpm *CPM) error {
 	fLen := uint8(fileSize / blkSize)
 
 	// Set record-count
-	if fLen > maxRC {
-		fcbPtr.RC = maxRC
-	} else {
+	fcbPtr.RC = maxRC
+	if fLen < maxRC {
 		fcbPtr.RC = fLen
 	}
 

--- a/cpm/cpm_bdos_test.go
+++ b/cpm/cpm_bdos_test.go
@@ -98,6 +98,52 @@ func TestConsoleInput(t *testing.T) {
 	}
 }
 
+func TestErrorReading(t *testing.T) {
+
+	// Create a new helper
+	c, err := New(WithPrinterPath("11.log"), WithInputDriver("error"))
+	if err != nil {
+		t.Fatalf("failed to create CPM")
+	}
+	c.Memory = new(memory.Memory)
+	c.fixupRAM()
+	c.StuffText("")
+	defer func() {
+		tErr := c.IOTearDown()
+		if tErr != nil {
+			t.Fatalf("teardown failed %s", tErr.Error())
+		}
+	}()
+
+	err = BdosSysCallAuxRead(c)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+
+	// ReadChar
+	err = BdosSysCallReadChar(c)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+
+	c.CPU.States.DE.Lo = 0xFF
+	err = BdosSysCallRawIO(c)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+
+	c.CPU.States.DE.Lo = 0xFD
+	err = BdosSysCallRawIO(c)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+
+	err = BdosSysCallReadString(c)
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+}
+
 func TestUnimplemented(t *testing.T) {
 	// Create a new helper
 	c, err := New(WithPrinterPath("12.log"))

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -178,7 +178,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		// Trim leading and trailing whitespace
 		str = strings.TrimSpace(str)
 
-		// Lower-case because the CCP will upper-case CLI arguments
+		// Lower-case so our driver name lookup works
 		return strings.ToLower(str)
 	}
 
@@ -243,6 +243,12 @@ func BiosSysCallReserved1(cpm *CPM) error {
 			return nil
 		}
 
+		// If the string starts with ":" we're just setting/changing the options
+		// and leaving the driver alone.
+		if str[0] == ':' {
+			str = cpm.output.GetName() + str
+		}
+
 		// Get the old value
 		old := cpm.output.GetName()
 
@@ -268,7 +274,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		nm := str
 		if len(val) == 2 {
 			if len(val[1]) > 0 {
-				options = " with options '" + val[1] + "'"
+				options = " with options '" + strings.ToUpper(val[1]) + "'"
 				nm = val[0]
 			}
 		}
@@ -281,7 +287,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		}
 
 		if len(val) == 2 {
-			cpm.output.WriteString("Options changed to " + val[1] + " for " + driver.GetName() + ".\r\n")
+			cpm.output.WriteString("Options changed to " + strings.ToUpper(val[1]) + " for " + driver.GetName() + ".\r\n")
 		}
 		return nil
 
@@ -388,6 +394,12 @@ func BiosSysCallReserved1(cpm *CPM) error {
 			return nil
 		}
 
+		// If the string starts with ":" we're just setting/changing the options
+		// and leaving the driver alone.
+		if str[0] == ':' {
+			str = cpm.input.GetName() + str
+		}
+
 		// Get the old value
 		oldName := cpm.input.GetName()
 
@@ -426,7 +438,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		nm := str
 		if len(val) == 2 {
 			if len(val[1]) > 0 {
-				options = " with options '" + val[1] + "'"
+				options = " with options '" + strings.ToUpper(val[1]) + "'"
 				nm = val[0]
 			}
 		}
@@ -438,7 +450,7 @@ func BiosSysCallReserved1(cpm *CPM) error {
 		}
 
 		if len(val) == 2 {
-			cpm.output.WriteString("Options changed to " + val[1] + " for " + driver.GetName() + ".\r\n")
+			cpm.output.WriteString("Options changed to " + strings.ToUpper(val[1]) + " for " + driver.GetName() + ".\r\n")
 		}
 		return nil
 

--- a/cpm/cpm_bios_test.go
+++ b/cpm/cpm_bios_test.go
@@ -197,7 +197,7 @@ func TestCustom(t *testing.T) {
 	// set to "null" - again with options
 	c.CPU.States.HL.SetU16(0x0002)
 	c.CPU.States.DE.SetU16(0xFE00)
-	c.Memory.SetRange(0xFE00, []byte{'n', 'u', 'l', 'l', ':', 'f', 'o', 0x00}...)
+	c.Memory.SetRange(0xFE00, []byte{':', 'f', 'o', 0x00}...)
 	err = BiosSysCallReserved1(c)
 	if err != nil {
 		t.Fatalf("error calling reserved function")
@@ -399,6 +399,15 @@ func TestCustom(t *testing.T) {
 		t.Fatalf("error calling reserved function %s", err)
 	}
 
+	// set to "stty", again this time with options too
+	c.CPU.States.HL.SetU16(0x0007)
+	c.CPU.States.DE.SetU16(0xFE00)
+	c.Memory.SetRange(0xFE00, []byte{':', 'f', 'o', 0x00}...)
+	err = BiosSysCallReserved1(c)
+	if err != nil {
+		t.Fatalf("error calling reserved function %s", err)
+	}
+
 	// set to an empty string
 	c.CPU.States.HL.SetU16(0x0007)
 	c.CPU.States.DE.SetU16(0xFE00)
@@ -406,15 +415,6 @@ func TestCustom(t *testing.T) {
 	err = BiosSysCallReserved1(c)
 	if err != nil {
 		t.Fatalf("error calling reserved function %s", err)
-	}
-
-	// set to "stty", again this time with options too
-	c.CPU.States.HL.SetU16(0x0007)
-	c.CPU.States.DE.SetU16(0xFE00)
-	c.Memory.SetRange(0xFE00, []byte{'s', 't', 't', 'y', ':', 'f', 'o', 0x00}...)
-	err = BiosSysCallReserved1(c)
-	if err != nil {
-		t.Fatalf("error calling reserved function")
 	}
 
 	// set to "stty", again this time with empty options


### PR DESCRIPTION
This pull-request, once complete, will close #219 by ensuring that shell-execution results in output being rendered to the console via our output layer - rather than inline.

Although the input-layer does have to echo characters at times, and handle overwriting when characters should be erased, significant usage of `fmt.Printf` is an architectural fault.

* [x] increased test-coverage for consolein
* [x] increased test-coverage for consoleout
* [x] increased test-coverage for cpm
* [x] ensuring that our functional tests "make test" don't break
* [x] update the cpm-dist AUTOEXEC.SUB to match my preferences.
   * https://github.com/skx/cpm-dist/commit/0cf69553ec1ead13af334686b8efac53611edb15 