### PR TITLE
Allow stuffing input into the console buffer

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -952,11 +952,15 @@ func (cpm *CPM) Execute(args []string) error {
 // a simple binary.
 //
 // If A:SUBMIT.COM and A:AUTOEXEC.SUB exist then we stuff the input-buffer with
-// a command to process them.
-func (cpm *CPM) RunAutoExec() {
+// a command to run the latter on startup.  Regardless of that we might also
+// add the extra-string
+func (cpm *CPM) RunAutoExec(extra string) {
 
 	// These files must be present
 	files := []string{"SUBMIT.COM", "AUTOEXEC.SUB"}
+
+	// How many of the expected files did we find?
+	found := 0
 
 	// If one of the files is missing we return
 	// without doing anything.
@@ -970,18 +974,25 @@ func (cpm *CPM) RunAutoExec() {
 
 		// Open it to see if it exists.
 		handle, err := os.OpenFile(dst, os.O_RDONLY, 0644)
-		if err != nil {
-
-			// We're assuming "file not found",
-			// or similar, here.
-			return
+		if err == nil {
+			found++
 		}
-
 		handle.Close()
 	}
 
-	// OK we have both files
-	cpm.input.StuffInput("SUBMIT AUTOEXEC\n")
+	text := ""
+
+	// If we got all the expected files then we can add the automation.
+	if found == len(files) {
+		text += "SUBMIT AUTOEXEC\n"
+	}
+
+	// Anything extra for the caller
+	text += extra
+
+	if len(text) > 0 {
+		cpm.input.StuffInput(text)
+	}
 }
 
 // SetStaticFilesystem allows adding a reference to an embedded filesystem.

--- a/cpm/cpm_test.go
+++ b/cpm/cpm_test.go
@@ -311,7 +311,7 @@ func TestAutoExec(t *testing.T) {
 
 	// Ensure there's _something_ to read
 	obj.StuffText("nothing\n")
-	obj.RunAutoExec()
+	obj.RunAutoExec("")
 
 	var out string
 	out, err = obj.input.ReadLine(200)
@@ -346,7 +346,7 @@ func TestAutoExec(t *testing.T) {
 
 	// Ensure there's _something_ to read
 	obj.StuffText("nothing\n")
-	obj.RunAutoExec()
+	obj.RunAutoExec("")
 
 	out, err = obj.input.ReadLine(200)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func main() {
 	logAll := flag.Bool("log-all", false, "Log all function invocations, including the noisy console I/O ones.")
 	logPath := flag.String("log-path", "", "Specify the file to write debug logs to.")
 	prnPath := flag.String("prn-path", "print.log", "Specify the file to write printer-output to.")
+	stuffTxt := flag.String("stuff", "", "Paste the supplied text into the input-buffer.")
 	showVersion := flag.Bool("version", false, "Report our version, and exit.")
 	timeout := flag.Int("timeout", 0, "Timeout execution after the given number of seconds")
 	useDirectories := flag.Bool("directories", false, "Use subdirectories on the host computer for CP/M drives.")
@@ -405,10 +406,19 @@ func main() {
 	// Show a startup-banner.
 	fmt.Printf("\ncpmulator %s\r\nConsole input:%s Console output:%s BIOS:0x%04X BDOS:0x%04X CCP:%s\r\n", cpmver.GetVersionString(), obj.GetInputDriver().GetName(), obj.GetOutputDriver().GetName(), obj.GetBIOSAddress(), obj.GetBDOSAddress(), obj.GetCCPName())
 
+	//
+	// If we've got some extra text to stuff into the input
+	// buffer we want to expand text appropriately.
+	//
+	extra := *stuffTxt
+	extra = strings.ReplaceAll(extra, "\\n", "\n")
+	extra = strings.ReplaceAll(extra, "\\r", "\r")
+	extra = strings.ReplaceAll(extra, "\\t", "\t")
+
 	// We will load AUTOEXEC.SUB, once, if it exists (*)
 	//
 	// * - Terms and conditions apply.
-	obj.RunAutoExec()
+	obj.RunAutoExec(extra)
 
 	// We load and re-run eternally - because many binaries the CCP
 	// would launch would end with "exit" which would otherwise cause


### PR DESCRIPTION
This pull-request adds a new CLI argument, so that you can inject input into the console-buffer from the start:

```
$ cpmulator -cd ../cpm-dist/   -stuff="type /\n" -input stty
```

This is enough to demonstrate the crash reported in #226, without any annoying blocking.  Now that this is complete it closes #227.

There is a minor complication, if you're setup so that you have a lot of jobs in "autoexec.sub" then the processing of that submit file might get killed - processing polls for keyboard input.  Ugh.