### PR TITLE
Improve implementation after testing with HiSoft C compiler

### DIFF
--- a/cpm/cpm.go
+++ b/cpm/cpm.go
@@ -467,9 +467,24 @@ func New(options ...Option) (*CPM, error) {
 		// We don't zero-pad
 		Fake: true,
 	}
+	bdos[42] = Handler{
+		Desc:    "F_LOCK",
+		Handler: BdosSysCallFileLock,
+		Fake:    true,
+	}
 	bdos[45] = Handler{
 		Desc:    "F_ERRMODE",
 		Handler: BdosSysCallErrorMode,
+		Fake:    true,
+	}
+	bdos[48] = Handler{
+		Desc:    "DRV_FLUSH",
+		Handler: BdosSysCallDriveFlush,
+		Fake:    true,
+	}
+	bdos[102] = Handler{ // HiSoft C Compiler 3.09
+		Desc:    "F_TIMEDATE",
+		Handler: BdosSysCallFileTimeDate,
 		Fake:    true,
 	}
 	bdos[105] = Handler{
@@ -518,6 +533,16 @@ func New(options ...Option) (*CPM, error) {
 	bios[5] = Handler{
 		Desc:    "LIST",
 		Handler: BiosSysCallPrintChar,
+		Fake:    true,
+	}
+	bios[6] = Handler{
+		Desc:    "PUNCH",
+		Handler: BiosSysCallPunch,
+		Fake:    true,
+	}
+	bios[7] = Handler{
+		Desc:    "READER",
+		Handler: BiosSysCallReader,
 		Fake:    true,
 	}
 	bios[15] = Handler{

--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -1684,8 +1684,30 @@ func BdosSysCallDriveReset(cpm *CPM) error {
 	return nil
 }
 
+// BdosSysCallFileLock implements a NOP version of F_LOCK
+func BdosSysCallFileLock(cpm *CPM) error {
+	cpm.CPU.States.HL.SetU16(0x00FF)
+	return nil
+}
+
 // BdosSysCallErrorMode implements a NOP version of F_ERRMODE.
 func BdosSysCallErrorMode(cpm *CPM) error {
+	cpm.CPU.States.HL.SetU16(0x0000)
+	cpm.CPU.States.AF.Hi = 0x00
+	return nil
+}
+
+// BdosSysCallDriveFlush implements a NOP version of DRV_FLUSH
+func BdosSysCallDriveFlush(cpm *CPM) error {
+	cpm.CPU.States.HL.SetU16(0x0000)
+	cpm.CPU.States.AF.Hi = 0x00
+	return nil
+}
+
+// BdosSysCallFileTimeDate implements a NOP version of F_TIMEDATE
+func BdosSysCallFileTimeDate(cpm *CPM) error {
+	cpm.CPU.States.HL.SetU16(0x0000)
+	cpm.CPU.States.AF.Hi = 0x00
 	return nil
 }
 

--- a/cpm/cpm_bdos_test.go
+++ b/cpm/cpm_bdos_test.go
@@ -790,6 +790,19 @@ func TestBDOSCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to call CPM")
 	}
+
+	err = BdosSysCallFileLock(c)
+	if err != nil {
+		t.Fatalf("failed to call CPM")
+	}
+	err = BdosSysCallDriveFlush(c)
+	if err != nil {
+		t.Fatalf("failed to call CPM")
+	}
+	err = BdosSysCallFileTimeDate(c)
+	if err != nil {
+		t.Fatalf("failed to call CPM")
+	}
 }
 
 // TestMakeCloseFile tests our file creation handler, and our close function too

--- a/cpm/cpm_bios.go
+++ b/cpm/cpm_bios.go
@@ -101,6 +101,17 @@ func BiosSysCallPrintChar(cpm *CPM) error {
 	return err
 }
 
+// BiosSysCallPunch implements a fake version of PUNCH (AUXOUT).
+func BiosSysCallPunch(cpm *CPM) error {
+	return nil
+}
+
+// BiosSysCallReader implements a fake version of READER (AUXIN).
+func BiosSysCallReader(cpm *CPM) error {
+	cpm.CPU.States.AF.Hi = 26 // Ctrl-Z
+	return nil
+}
+
 // BiosSysCallPrinterStatus returns status of current printer device.
 //
 // This is fake, and always returns "ready".

--- a/cpm/cpm_bios_test.go
+++ b/cpm/cpm_bios_test.go
@@ -7,6 +7,29 @@ import (
 	"github.com/skx/cpmulator/memory"
 )
 
+func TestMisc(t *testing.T) {
+	// Create a new helper
+	c, err := New(WithPrinterPath("1.log"))
+	if err != nil {
+		t.Fatalf("failed to create CPM")
+	}
+
+	// Punch (auxout) does nothing.
+	err = BiosSysCallPunch(c)
+	if err != nil {
+		t.Fatalf("failed to call CPM")
+	}
+
+	// Reader (auxin) should return Ctrl-Z
+	err = BiosSysCallReader(c)
+	if err != nil {
+		t.Fatalf("failed to call CPM")
+	}
+	if c.CPU.States.AF.Hi != 26 {
+		t.Fatalf("auxin result was wrong %02X", c.CPU.States.AF.Hi)
+	}
+}
+
 func TestStatus(t *testing.T) {
 
 	// Create a new helper


### PR DESCRIPTION
This pull-request is part of #234, making some improvements but not
yet resolving the issue.   It seems there are some issues with our
implementation which are not yet resolved however there are some
clear issues:

* We're missing some of the syscalls that the binaries call.
* We have issues handling the $-files, as created by SUBMIT.COM

I think we also don't reset FCB details when files are opened which leads to reading/writing to the wrong offsets if the caller doesn't pay attention.  (i.e. S1/CR/R0/R1/R2/Ex should be zero-filled when a file is made/opened, maybe?)