### PR TITLE
Update to avoid modifying the FCB when file open/made

### DIFF
--- a/fcb/fcb.go
+++ b/fcb/fcb.go
@@ -115,6 +115,33 @@ func (f *FCB) GetFileName() string {
 	return strings.TrimSpace(name)
 }
 
+// GetCacheKey returns a string which can be used for caching this
+// object in some way - it's the name of the file, as seen by the
+// CP/M system.
+func (f *FCB) GetCacheKey() string {
+	t := ""
+
+	// Name
+	for _, c := range f.Name {
+		if unicode.IsPrint(rune(c)) {
+			t += string(c)
+		} else {
+			t += " "
+		}
+	}
+
+	// Suffix
+	for _, c := range f.Type {
+		if unicode.IsPrint(rune(c)) {
+			t += string(c)
+		} else {
+			t += " "
+		}
+	}
+	return t
+
+}
+
 // AsBytes returns the entry of the FCB in a format suitable
 // for copying to RAM.
 func (f *FCB) AsBytes() []uint8 {

--- a/fcb/fcb_test.go
+++ b/fcb/fcb_test.go
@@ -78,6 +78,9 @@ func TestFCBFromString(t *testing.T) {
 	if f.GetType() != "   " {
 		t.Fatalf("unexpected suffix '%v'", f.GetType())
 	}
+	if f.GetCacheKey() != "FOO        " {
+		t.Fatalf("name wrong, got '%v'", f.GetCacheKey())
+	}
 
 	// Try a long name, to confirm it is truncated
 	f = FromString("c:this-is-a-long-name")
@@ -105,6 +108,9 @@ func TestFCBFromString(t *testing.T) {
 	if f.GetFileName() != "THIS-IS-.LON" {
 		t.Fatalf("wrong name returned, got %v", f.GetFileName())
 	}
+	if f.GetCacheKey() != "THIS-IS-LON" {
+		t.Fatalf("wrong cache returned, got %v", f.GetCacheKey())
+	}
 
 	// wildcard
 	f = FromString("c:steve*.*")
@@ -127,6 +133,15 @@ func TestFCBFromString(t *testing.T) {
 	}
 	if f.GetType() != "C??" {
 		t.Fatalf("name wrong, got '%v'", f.GetName())
+	}
+
+	f = FromString("")
+	f.Name[0] = 0x00
+	f.Name[1] = 0x01
+	f.Type[0] = 0x00
+	f.Type[1] = 0x01
+	if f.GetCacheKey() != "           " {
+		t.Fatalf("wrong cache returned, got %v", f.GetCacheKey())
 	}
 
 }


### PR DESCRIPTION
We've moved to storing the cache of the open files on the host-side using a key based on the filename.  This means that we no longer modify the Al[0] and Al[1] members of the FCB in-ram..

This closes #236 by making the caching an internal-detail, rather than something that guest-binaries could notice (via the changes to Al).