### PR TITLE
Ensure we uncache entries when deleting files

### DIFF
--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -722,6 +722,17 @@ func BdosSysCallDeleteFile(cpm *CPM) error {
 		// Host path
 		path := entry.Host
 
+		// Ensure we don't have this cached
+		x := fcb.FromString(entry.Name)
+
+		// If we have a cached handle ensure we close the file,
+		// then delete the entry.
+		obj, ok := cpm.files[x.GetCacheKey()]
+		if ok {
+			obj.handle.Close()
+			delete(cpm.files, x.GetCacheKey())
+		}
+
 		slog.Debug("SysCallDeleteFile: deleting file",
 			slog.String("path", path))
 


### PR DESCRIPTION
This pull-request closes #241 by ensuring we remove entries from our internal cache of filehandles when the "Delete File"  BDOS syscall is called.

The pull-request adds a corresponding test-case to ensure this doesn't come back to haunt us.