### PR TITLE
Improve globbing by getting size at the time we find files

### DIFF
--- a/cpm/cpm_bdos.go
+++ b/cpm/cpm_bdos.go
@@ -635,8 +635,10 @@ func BdosSysCallFileClose(cpm *CPM) error {
 
 // BdosSysCallFindFirst finds the first filename, on disk, that matches the glob in the FCB supplied in DE.
 func BdosSysCallFindFirst(cpm *CPM) error {
+
 	// The pointer to the FCB
 	ptr := cpm.CPU.States.DE.U16()
+
 	// Get the bytes which make up the FCB entry.
 	xxx := cpm.Memory.GetRange(ptr, fcb.SIZE)
 
@@ -727,25 +729,12 @@ func BdosSysCallFindFirst(cpm *CPM) error {
 	// Create a new FCB and store it in the DMA entry
 	x := fcb.FromString(res[0].Name)
 
-	// Get the file-size in records, and add to the FCB
-	tmp, err := os.OpenFile(res[0].Host, os.O_RDONLY, 0644)
-	if err == nil {
-		defer tmp.Close()
+	// Get file size, in blocks.
+	x.RC = uint8(res[0].Size / blkSize)
 
-		fi, err := tmp.Stat()
-		if err == nil {
-
-			fileSize := fi.Size()
-
-			// Get file size, in blocks
-			x.RC = uint8(fileSize / blkSize)
-
-			// If the size is bigger than a multiple we deal with that.
-			if fileSize > int64(int64(x.RC)*int64(blkSize)) {
-				x.RC++
-			}
-
-		}
+	// If the size is bigger than a multiple we deal with that.
+	if res[0].Size > int64(int64(x.RC)*int64(blkSize)) {
+		x.RC++
 	}
 
 	// Log the first result we're returning.
@@ -783,25 +772,12 @@ func BdosSysCallFindNext(cpm *CPM) error {
 	// Create a new FCB and store it in the DMA entry
 	x := fcb.FromString(res.Name)
 
-	// Get the file-size in records, and add to the FCB
-	tmp, err := os.OpenFile(res.Host, os.O_RDONLY, 0644)
-	if err == nil {
-		defer tmp.Close()
+	// Get file size, in blocks.
+	x.RC = uint8(res.Size / blkSize)
 
-		fi, err := tmp.Stat()
-		if err == nil {
-
-			fileSize := fi.Size()
-
-			// Get file size, in blocks
-			x.RC = uint8(fileSize / blkSize)
-
-			// If the size is bigger than a multiple we deal with that.
-			if fileSize > int64(int64(x.RC)*int64(blkSize)) {
-				x.RC++
-			}
-
-		}
+	// If the size is bigger than a multiple we deal with that.
+	if res.Size > int64(int64(x.RC)*int64(blkSize)) {
+		x.RC++
 	}
 
 	// Log that we're returning the next result.

--- a/fcb/fcb_test.go
+++ b/fcb/fcb_test.go
@@ -2,6 +2,7 @@ package fcb
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 )
 
@@ -207,11 +208,28 @@ func TestGetMatches(t *testing.T) {
 		t.Fatalf("failed to get matches")
 	}
 
-	if len(out) != 1 {
-		t.Fatalf("unexpected number of matches")
+	if len(out) < 10 {
+		t.Fatalf("unexpected number of matches got %d", len(out))
 	}
-	if out[0].Host != "../main.go" {
+
+	// sort the files - so we can be predictable
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+
+	// first file, alphabetically
+	if out[0].Host != "../ccp/ccp.go" {
 		t.Fatalf("unexpected name %s", out[0].Host)
+	}
+
+	found := false
+	for _, e := range out {
+		if e.Host == "../static/static.go" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("failed to find static.go")
 	}
 
 	_, err = f.GetMatches("!>>//path/not/found")


### PR DESCRIPTION
This stops having to stat files post-find, instead we can save away the size as we find the files.

(ie.  We use filepath.Walk instead of os.ReadDir so we get access to the fs.FileInfo immediately.)